### PR TITLE
Adding RGBank

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -33,8 +33,9 @@ mod 'puppetlabs/vcsrepo', '1.5.0'
 mod 'puppetlabs/sqlserver', '1.2.0'
 
 # Forge Community Modules
+mod 'jfryman-selinux', '0.4.0'
 mod 'ghoneycutt-ssh', '3.52.0'
-mod 'puppet-archive', '1.3.0'
+mod 'camptocamp-archive', '0.9.0'
 mod 'garethr/docker', '5.3.0'
 mod 'trlinkin/domain_membership', '1.1.2'
 mod 'ipcrm/echo', '0.1.3'
@@ -69,9 +70,15 @@ mod 'gogs',
   :git => 'https://github.com/ipcrm/puppet-gogs.git',
   :ref => '59f7800ad3512cf371c47902996df0b927267805'
 
+mod 'mayflower-php', '3.4.1'
+mod 'puppet-nginx', '0.7.1'
 mod 'bodgit-rngd', '2.0.0'
 mod 'jonono-auditpol', '0.1.2'
 mod 'nexcess-auditd', '2.0.0'
 mod 'demo_cis',
   :git => 'https://github.com/ipcrm/ipcrm-demo_cis.git',
   :ref => 'dee17aa1cd6619290ed6657d8f70dbfcafbb3b08'
+
+mod 'rgbank',
+  :git => 'https://github.com/ipcrm/puppetlabs-rgbank.git',
+  :ref => 'master'

--- a/site/profile/manifests/app/db/mysql/client.pp
+++ b/site/profile/manifests/app/db/mysql/client.pp
@@ -1,0 +1,15 @@
+class profile::app::db::mysql::client {
+
+  case $::facts['kernel'] {
+    'windows': {
+      fail('Unsupported OS')
+    }
+    default: {
+      include ::mysql::client
+      class {'::mysql::bindings':
+          php_enable => true,
+      }
+    }
+  }
+
+}

--- a/site/profile/manifests/app/db/mysql/server.pp
+++ b/site/profile/manifests/app/db/mysql/server.pp
@@ -1,0 +1,13 @@
+class profile::app::db::mysql::server {
+
+  case $::facts['kernel'] {
+    'windows': {
+      fail('Unsupported OS')
+    }
+    default: {
+      include ::mysql::server
+      include ::mysql::client
+    }
+  }
+
+}

--- a/site/profile/manifests/app/rgbank.pp
+++ b/site/profile/manifests/app/rgbank.pp
@@ -1,0 +1,34 @@
+class profile::app::rgbank {
+
+  if $::kernel == 'windows' {
+    fail('Unsupported OS')
+  }
+
+  require ::profile::app::rgbank::db
+  require ::profile::app::rgbank::webhead
+
+  rgbank::db {'default':
+    user     => 'rgbank',
+    password => 'rgbank',
+  }
+
+  rgbank::web {'default':
+    db_name     => 'rgbank-default',
+    db_host     => 'localhost',
+    db_user     => 'rgbank',
+    db_password => 'rgbank',
+    listen_port => 8888,
+  }
+
+  $default = {
+    'host' => $::fqdn,
+    'port' => 8888,
+    'ip'   => '127.0.0.1',
+  }
+
+  rgbank::load {'default':
+    balancermembers => [ $default, ],
+  }
+
+
+}

--- a/site/profile/manifests/app/rgbank/db.pp
+++ b/site/profile/manifests/app/rgbank/db.pp
@@ -1,0 +1,5 @@
+class profile::app::rgbank::db {
+
+  include ::profile::app::db::mysql::server
+
+}

--- a/site/profile/manifests/app/rgbank/webhead.pp
+++ b/site/profile/manifests/app/rgbank/webhead.pp
@@ -1,0 +1,16 @@
+class profile::app::rgbank::webhead {
+
+  class{'::profile::app::webserver::nginx':
+    php => true,
+  }
+
+  file { 'default-nginx-disable':
+    ensure  => absent,
+    path    => '/etc/nginx/conf.d/default.conf',
+    require => Package['nginx'],
+    notify  => Service['nginx'],
+  }
+
+  include ::profile::app::db::mysql::client
+
+}

--- a/site/profile/manifests/app/webserver/apache.pp
+++ b/site/profile/manifests/app/webserver/apache.pp
@@ -10,4 +10,6 @@ class profile::app::webserver::apache (
     default_vhost => $default_vhost,
   }
 
+  contain ::profile::app::webserver::apache::php
+
 }

--- a/site/profile/manifests/app/webserver/apache/php.pp
+++ b/site/profile/manifests/app/webserver/apache/php.pp
@@ -1,0 +1,3 @@
+class profile::app::webserver::apache::php {
+  include ::apache::mod::php
+}

--- a/site/profile/manifests/app/webserver/nginx.pp
+++ b/site/profile/manifests/app/webserver/nginx.pp
@@ -1,0 +1,21 @@
+class profile::app::webserver::nginx(
+  Boolean $php = false,
+){
+
+  if $::kernel == 'windows' {
+    fail('Unsupported OS')
+  }
+
+  if $php == true {
+
+    class { '::php':
+      composer => false,
+    }
+
+    Class['php'] -> Class['nginx']
+  }
+
+  class { '::nginx': }
+
+
+}

--- a/site/role/manifests/rgbank_standalone.pp
+++ b/site/role/manifests/rgbank_standalone.pp
@@ -1,0 +1,5 @@
+class role::rgbank_standalone {
+  include ::profile::platform::baseline
+  include ::profile::app::rgbank
+
+}

--- a/spec/classes/profile/profile_app_rgbank_spec.rb
+++ b/spec/classes/profile/profile_app_rgbank_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'profile::app::rgbank' do
+
+    SUPPORTED_OS.each do |os, facts|
+
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        before(:each) do
+          Puppet::Parser::Functions.newfunction(:puppetdb_query, :type => :rvalue) do |args|
+            [{'facts'=>{'fqdn'=> 'testserver'}}]
+          end
+        end
+
+        if Gem.win_platform?
+          context "unsupported OS" do
+            it { is_expected.to compile.and_raise_error(/Unsupported OS/)  }
+          end
+        else
+          context "without any parameters" do
+            it { is_expected.to compile.with_all_deps }
+          end
+        end
+
+      end
+    end
+end

--- a/spec/classes/role/role_rgbank_standalone_spec.rb
+++ b/spec/classes/role/role_rgbank_standalone_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'role::rgbank_standalone' do
+
+    SUPPORTED_OS.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        before(:each) do
+          Puppet::Parser::Functions.newfunction(:puppetdb_query, :type => :rvalue) do |args|
+            [{'facts'=>{'fqdn'=> 'testserver'}}]
+          end
+        end
+
+        if Gem.win_platform?
+          context "unsupported OS" do
+            it { is_expected.to compile.and_raise_error(/Unsupported OS/)  }
+          end
+        else
+          context "without any parameters" do
+            it { is_expected.to compile.with_all_deps }
+          end
+        end
+
+      end
+    end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,12 +23,13 @@ add_custom_fact :memory, {
   }
 }
 
-
 if !Gem.win_platform?
   add_custom_fact :staging_http_get,    'curl'
   add_custom_fact :ssh_version,         'OpenSSH_6.6.1p1'
   add_custom_fact :ssh_version_numeric, '6.6.1'
   add_custom_fact :gogs_version,        '0.11.19'
+  add_custom_fact :jenkins_plugins, nil
+  add_custom_fact :root_home, '/root'
 else
   add_custom_fact :choco_install_path,  'C:\ProgramData\chocolatey'
   add_custom_fact :chocolateyversion,   '0.10.7'


### PR DESCRIPTION
Adding rgbank module with a new profile, profile::app:rgbank, that can
be used on a standalone machine as a 'full stack' example.
Additionally, their two sub-profiles, webhead and db, that can be used
to setup the pre-reqs when deploying rgbank via multi-node app orch.