### PR TITLE
Lengthening the password 

### DIFF
--- a/site/profile/manifests/platform/baseline/users/windows.pp
+++ b/site/profile/manifests/platform/baseline/users/windows.pp
@@ -3,7 +3,7 @@ class profile::platform::baseline::users::windows {
   # CUSTOM USERS
   user { 'Sample Demo':
     ensure   => present,
-    password => 'Puppet4Life!',
+    password => 'Puppet4Life!17',
     groups   => ['Administrators'],
   }
 


### PR DESCRIPTION
To meet CIS standards of 14 characters I'm adding 2 digits to the password so this demo will be compatible with demo_cis. Fixes https://github.com/puppetlabs-seteam/control-repo/issues/58