### PR TITLE
enable insecure winrm for discovery demos

### DIFF
--- a/site/profile/manifests/platform/baseline/windows/bootstrap.pp
+++ b/site/profile/manifests/platform/baseline/windows/bootstrap.pp
@@ -34,4 +34,17 @@ class profile::platform::baseline::windows::bootstrap {
 
   }
 
+  registry::value { 'enable insecure winrm':
+    key    => 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service',
+    value  => 'AllowUnencryptedTraffic',
+    data   => "1",
+    type   => 'dword',
+    notify => Service['WinRM'],
+  }
+
+  service {'WinRM':
+    ensure => 'running',
+    enable => true
+  }
+
 }


### PR DESCRIPTION
Disable secure only connections for WinRM to demo Discovery easier in our SE Demo env.  This is required for non-kerberos auth (no domain).