### PR TITLE
change cloudshop check from IIS to OS version

### DIFF
--- a/site/profile/manifests/app/cloudshop.pp
+++ b/site/profile/manifests/app/cloudshop.pp
@@ -2,7 +2,7 @@ class profile::app::cloudshop {
 
   case $::kernel {
     'windows': {
-      if $::iis_version == '8.5' {
+      if $::operatingsystemrelease == '2012 R2' {
         include profile::app::cloudshop::sqlserver::init
         include profile::app::cloudshop::webapp::db
         include profile::app::cloudshop::webapp::init


### PR DESCRIPTION
change cloudshop check from IIS to OS version as the check was looking got IIS before installing, thus never installing.