### PR TITLE
Clean up firewall rules in puppet profile

### DIFF
--- a/site/profile/manifests/puppet/master.pp
+++ b/site/profile/manifests/puppet/master.pp
@@ -11,40 +11,4 @@ class profile::puppet::master {
   include ::profile::puppet::master::hiera
   include ::profile::puppet::master::node_manager
 
-  firewall { '100 allow Puppet master access':
-    dport  => '8140',
-    proto  => tcp,
-    action => accept,
-  }
-
-  firewall { '100 allow Puppet orch access':
-    dport  => '8142',
-    proto  => tcp,
-    action => accept,
-  }
-
-  firewall { '100 allow Puppet client-tools access':
-    dport  => '8143',
-    proto  => tcp,
-    action => accept,
-  }
-
-  firewall { '100 allow ActiveMQ MCollective access':
-    dport  => '61614',
-    proto  => tcp,
-    action => accept,
-  }
-
-  firewall { '100 allow PE RBAC API access':
-    dport  => '4433',
-    proto  => tcp,
-    action => accept,
-  }
-
-  firewall { '100 allow PE Console access':
-      dport  => '443',
-      proto  => tcp,
-      action => accept,
-  }
-
 }

--- a/site/profile/manifests/puppet/master/firewall.pp
+++ b/site/profile/manifests/puppet/master/firewall.pp
@@ -7,10 +7,14 @@ class profile::puppet::master::firewall {
     action => 'accept',
   }
 
-  firewall { '110 puppetmaster allow all': dport  => '8140';  }
-  firewall { '110 console allow all':      dport  => '443';   }
-  firewall { '110 mcollective allow all':  dport  => '61613'; }
-  firewall { '110 pxp orch allow all':     dport  => '8142';  }
+  firewall { '110 allow PE Console access':           dport => '443';   }
+  firewall { '110 allow PE Services API access':      dport => '4433';  }
+  firewall { '110 allow PuppetDB access':             dport => '8081';  }
+  firewall { '110 allow Puppet Server access':        dport => '8140';  }
+  firewall { '110 allow Puppet PCP Broker access':    dport => '8142';  }
+  firewall { '110 allow Puppet Orchestrator access':  dport => '8143';  }
+  firewall { '110 allow Code Manager access':         dport => '8170';  }
+  firewall { '110 allow MCollective/ActiveMQ access': dport => '61613'; }
 
 }
 


### PR DESCRIPTION
This commit removes redundant firewall rules from the
profile::puppet::master class, due to the firewall rules required all
being specified by the profile::puppet::master::firewall class, which is
already included by profile::puppet::master.

Besides getting rid of unnecessary redundancy I also needed to clean up
and improve the profile::puppet::master::firewall class for independent
usage on a standard PE server.