### PR TITLE
Seteam master

### DIFF
--- a/site/profile/manifests/puppet/seteam_master.pp
+++ b/site/profile/manifests/puppet/seteam_master.pp
@@ -1,4 +1,4 @@
-class profile::puppet::master {
+class profile::puppet::seteam_master {
 
   if $::facts['kernel'] != 'Linux' {
     fail('Unsupported OS!')

--- a/site/role/functions/require_kernel.pp
+++ b/site/role/functions/require_kernel.pp
@@ -1,0 +1,9 @@
+function role::require_kernel(
+  String[1] $kernel,
+) {
+
+  if $::facts['kernel'] != $kernel {
+    fail('Unsupported OS!')
+  }
+
+}

--- a/site/role/manifests/master_server.pp
+++ b/site/role/manifests/master_server.pp
@@ -1,4 +1,6 @@
+# DEPRECATED; renamed to role::seteam_puppet_master.
+# This role retained temporarily for backwards compatiblity.
+# Please use the role::seteam_puppet_master instead.
 class role::master_server {
-  include ::profile::platform::baseline
-  include ::profile::puppet::master
+  contain role::seteam_puppet_master
 }

--- a/site/role/manifests/puppet_master.pp
+++ b/site/role/manifests/puppet_master.pp
@@ -1,0 +1,4 @@
+class role::puppet_master {
+  include profile::platform::baseline
+  include profile::puppet::master::firewall
+}

--- a/site/role/manifests/puppet_master.pp
+++ b/site/role/manifests/puppet_master.pp
@@ -1,4 +1,6 @@
 class role::puppet_master {
+  role::require_kernel('Linux')
+
   include profile::platform::baseline
   include profile::puppet::master::firewall
 }

--- a/site/role/manifests/seteam_puppet_master.pp
+++ b/site/role/manifests/seteam_puppet_master.pp
@@ -1,0 +1,4 @@
+class role::seteam_puppet_master {
+  include profile::platform::baseline
+  include profile::puppet::seteam_master
+}

--- a/spec/classes/profile/profile_puppet_seteam_master_spec.rb
+++ b/spec/classes/profile/profile_puppet_seteam_master_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'profile::puppet::master' do
+describe 'profile::puppet::seteam_master' do
     SUPPORTED_OS.each do |os, facts|
       context "on #{os}" do
         let(:facts) do

--- a/spec/classes/role/role_puppet_master_spec.rb
+++ b/spec/classes/role/role_puppet_master_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'role::puppet_master' do
+
+    SUPPORTED_OS.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        let(:pre_condition) {'
+          service {"pe-puppetserver": ensure => running }
+        '}
+
+        if Gem.win_platform?
+          context "unsupported OS" do
+            it { is_expected.to compile.and_raise_error(/Unsupported OS/)  }
+          end
+        else
+          context "without any parameters" do
+            it { is_expected.to compile.with_all_deps }
+          end
+        end
+
+      end
+    end
+
+end

--- a/spec/classes/role/role_seteam_puppet_master_spec.rb
+++ b/spec/classes/role/role_seteam_puppet_master_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'role::seteam_puppet_master' do
+
+    SUPPORTED_OS.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        let(:pre_condition) {'
+          service {"pe-puppetserver": ensure => running }
+        '}
+
+        if Gem.win_platform?
+          context "unsupported OS" do
+            it { is_expected.to compile.and_raise_error(/Unsupported OS/)  }
+          end
+        else
+          context "without any parameters" do
+            it { is_expected.to compile.with_all_deps }
+          end
+        end
+
+      end
+    end
+
+end


### PR DESCRIPTION
I have a need to introduce a new role for a more general, standard
Puppet master role, one that can be configured and integrated with
standard supporting services such as Gitlab, Github, CD4PE, and so
forth.

The previously existing role::master_server did not meet these
requirements. I therefore created a new role, called role::puppet_master.

Now that role::puppet_master exists though, it can be confused with
role::master_server. In order to reduce confusion in naming I am
creating a role to replace role::master_server. The replacement is
called role::seteam_puppet_master.

The "seteam" prefix conveys that this is a variant of a "normal" puppet
master. Using "seteam" specifically communicates the business purpose of
it being a variant for and used by the seteam.

The old role, role::master_server, is retained in this commit for
temporary backwards compatility and has been modified to simply contain
the new role, role::seteam_puppet_master.

Next steps will be to modify the build system to use
role::seteam_puppet_master directly, so that the deprecated
role::master_server can be removed from the control repository.
