### PR TITLE
Set a seemingly-required docker::run flag

### DIFF
--- a/site/profile/manifests/puppet/cd4pe.pp
+++ b/site/profile/manifests/puppet/cd4pe.pp
@@ -3,6 +3,12 @@ class profile::puppet::cd4pe (
 ) {
   include docker
 
+  # Set this default because there seems to be a bug in puppetlabs/docker 3.0.0
+  # that makes it effectively required.
+  Docker::Run {
+    health_check_interval => 30,
+  }
+
   ['3306', '7000', '8000', '8080', '8081'].each |$port| {
     firewall { "100 allow cd4pe ${port}":
       proto  => 'tcp',


### PR DESCRIPTION
There seems to be a bug in the upstream puppetlabs/docker module. If
health_check_interval is not supplied, an invalid flag will be written
to the ExecStart script.