### PR TITLE
MCollective/ActiveMQ is old and busted

### DIFF
--- a/site/profile/manifests/puppet/master/firewall.pp
+++ b/site/profile/manifests/puppet/master/firewall.pp
@@ -14,8 +14,6 @@ class profile::puppet::master::firewall {
   firewall { '110 allow Puppet PCP Broker access':    dport => '8142';  }
   firewall { '110 allow Puppet Orchestrator access':  dport => '8143';  }
   firewall { '110 allow Code Manager access':         dport => '8170';  }
-  #MCollective/ActiveMQ was deprecated in 2018.4 and removed in 2019.0
-  #firewall { '110 allow MCollective/ActiveMQ access': dport => '61613'; }
 
 }
 

--- a/site/profile/manifests/puppet/master/firewall.pp
+++ b/site/profile/manifests/puppet/master/firewall.pp
@@ -14,7 +14,8 @@ class profile::puppet::master::firewall {
   firewall { '110 allow Puppet PCP Broker access':    dport => '8142';  }
   firewall { '110 allow Puppet Orchestrator access':  dport => '8143';  }
   firewall { '110 allow Code Manager access':         dport => '8170';  }
-  firewall { '110 allow MCollective/ActiveMQ access': dport => '61613'; }
+  #MCollective/ActiveMQ was deprecated in 2018.4 and removed in 2019.0
+  #firewall { '110 allow MCollective/ActiveMQ access': dport => '61613'; }
 
 }
 


### PR DESCRIPTION
2018.4 doesn't install MCollective by default (thought it will upgrade MCollective if present) and 2019.0 doesn't have MCollective.

This change comments out the firewall port to lessen the attach surface, but makes a note in case anybody gets confused.

A further option would be to check a fact and conditionally include the firewall port, but it's unlikely that will ever be need again, because Bolt!