### PR TITLE
Don't duplicate spec tests on Windows platform

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,9 +67,13 @@ stage('Run Spec Tests') {
     'linux::profile::spec': {
       runSpecTests('linux')
     },
-    'windows::profile::spec': {
-      runSpecTests('windows')
-    }
+    // Spec tests should not execute differently on Windows vs. Linux.
+    // There is therefore no reason to run the same test on multiple platforms.
+    // Windows executes *extremely slowly* due to inefficiency checking out 
+    // module dependencies, so it's quite costly to duplicate this test.
+    // 'windows::profile::spec': {
+    //   runSpecTests('windows')
+    // }
   )
 }
 


### PR DESCRIPTION
There's no benefit to this. Spec tests run the same whether the executor
is Linux or the executor is Windows. The only time in the Puppet
ecosystem where you actually need a Windows system to run a test on is:

    * When you are validating that you can use a windows workstation
      for dev work at all
    * When you are doing agent-side testing, such as acceptance testing

Because it takes SO LONG to duplicate the spec tests on Windows, we
should really just not do that. It's an impediment to dev work and
doesn't add any value.

If I'm wrong, change my mind. :)