### PR TITLE
changed permit_root_login to be false by default

### DIFF
--- a/site-modules/profile/manifests/platform/baseline/linux/ssh.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/ssh.pp
@@ -1,5 +1,5 @@
 class profile::platform::baseline::linux::ssh (
-  String $permit_root_login = 'yes',
+  String $permit_root_login = 'no',
 ) {
 
   if !defined(Class['ssh']){


### PR DESCRIPTION
Starting with the PE2019.0.2 AMI, the root login should be disabled by default. Instead, login is enabled as centos user, either with your own AWS private key if you are using awskit, or the `training.pem` key if you are using hydra.

Leaving root login open is a huge security risk in AWS environments.