### PR TITLE
checking whether role class exists before including it

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -12,6 +12,8 @@ node default {
   # Check if we've set the role for this node via trusted fact, pp_role.  If yes; include that role directly here.
   if !empty( $trusted['extensions']['pp_role'] ) {
     $role = $trusted['extensions']['pp_role']
-    include "role::${trusted['extensions']['pp_role']}"
+    if defined("role::${role}") {
+      include "role::${role}"
+    }
   }
 }


### PR DESCRIPTION
This prevents puppet from failing on hydra PM instances which define the role `master_server` in their trusted role fact.