### PR TITLE
fix path attribute

### DIFF
--- a/site-modules/profile/manifests/puppet/splunk_hec.pp
+++ b/site-modules/profile/manifests/puppet/splunk_hec.pp
@@ -14,7 +14,7 @@ class profile::puppet::splunk_hec {
     setting           => 'reports',
     key_val_separator => '=',
     value             => 'puppetdb,splunk_hec',
-    path              => $facts['puppet_config'],
+    path              => $settings::config,
     notify            => Service['pe-puppetserver']
   }
 }


### PR DESCRIPTION
Currently fails on the path attribute value in the ini_setting resource block. 
Suggest changing it from
path              => $facts['puppet_config'],
to:
path              => $settings::config,
