### PR TITLE
Hipaa profile win update

### DIFF
--- a/site-modules/profile/manifests/platform/compliance/hipaa/windows.pp
+++ b/site-modules/profile/manifests/platform/compliance/hipaa/windows.pp
@@ -22,6 +22,7 @@ class profile::platform::compliance::hipaa::windows {
     unless      => [
       [ 'name', '==', 'Administrator' ],
       [ 'name', '==', 'Guest' ],
+      [ 'name', '==', 'Guest' ],
       [ 'name', '==', 'Local Admin 1' ],
       [ 'name', '==', 'Local Admin 2' ],
     ]

--- a/site-modules/profile/manifests/platform/compliance/hipaa/windows.pp
+++ b/site-modules/profile/manifests/platform/compliance/hipaa/windows.pp
@@ -22,7 +22,7 @@ class profile::platform::compliance::hipaa::windows {
     unless      => [
       [ 'name', '==', 'Administrator' ],
       [ 'name', '==', 'Guest' ],
-      [ 'name', '==', 'Guest' ],
+      [ 'name', '==', 'DefaultAccount' ],
       [ 'name', '==', 'Local Admin 1' ],
       [ 'name', '==', 'Local Admin 2' ],
     ]


### PR DESCRIPTION
Current HIPAA Windows profile does not list "DefaultAccount" in the ignore list for the purge directive.  Applying this profile fails, as it tries to delete "DefaultAccount", which is a built in account on windows 2016.

This request adds DefaultAccount in as an ignored user name in the list.

Testing it would involve applying the Hippa profile against windows nodes.