### PR TITLE
Add binding (port) information to iis_site resource

### DIFF
--- a/site-modules/profile/manifests/app/sample_website/windows.pp
+++ b/site-modules/profile/manifests/app/sample_website/windows.pp
@@ -1,6 +1,6 @@
 class profile::app::sample_website::windows (
   String $doc_root           = 'C:\inetpub\wwwroot\sample_website',
-  Integer $webserver_port    = 8002,
+  Integer $webserver_port    = 80,
   String $apppool            = 'sample_website',
   String $website_source_dir = 'puppet:///modules/profile/app/sample_website',
   Boolean $enable_monitoring = false,

--- a/site-modules/profile/manifests/app/sample_website/windows.pp
+++ b/site-modules/profile/manifests/app/sample_website/windows.pp
@@ -1,6 +1,6 @@
 class profile::app::sample_website::windows (
   String $doc_root           = 'C:\inetpub\wwwroot\sample_website',
-  Integer $webserver_port    = 80,
+  Integer $webserver_port    = 8001,
   String $apppool            = 'sample_website',
   String $website_source_dir = 'puppet:///modules/profile/app/sample_website',
   Boolean $enable_monitoring = false,

--- a/site-modules/profile/manifests/app/sample_website/windows.pp
+++ b/site-modules/profile/manifests/app/sample_website/windows.pp
@@ -27,8 +27,8 @@ class profile::app::sample_website::windows (
     applicationpool => $apppool,
     bindings  => [
       {
-        'bindinginformation'   => "*:$webserver_port:",
-        'protocol'   => 'http',
+        'bindinginformation'    => "*:$webserver_port:",
+        'protocol'              => 'http',
       },
     ],
     require         => [

--- a/site-modules/profile/manifests/app/sample_website/windows.pp
+++ b/site-modules/profile/manifests/app/sample_website/windows.pp
@@ -25,6 +25,12 @@ class profile::app::sample_website::windows (
     ensure          => 'started',
     physicalpath    => $doc_root,
     applicationpool => $apppool,
+    bindings  => [
+      {
+        'bindinginformation'   => "*:$webserver_port:",
+        'protocol'   => 'http',
+      },
+    ],
     require         => [
       Iis_application_pool['sample_website']
     ],

--- a/site-modules/profile/manifests/app/sample_website/windows.pp
+++ b/site-modules/profile/manifests/app/sample_website/windows.pp
@@ -1,6 +1,6 @@
 class profile::app::sample_website::windows (
   String $doc_root           = 'C:\inetpub\wwwroot\sample_website',
-  Integer $webserver_port    = 8001,
+  Integer $webserver_port    = 8002,
   String $apppool            = 'sample_website',
   String $website_source_dir = 'puppet:///modules/profile/app/sample_website',
   Boolean $enable_monitoring = false,


### PR DESCRIPTION
The webserver_port parameter was being passed to the firewall exception resource but not the iis_site resource.  Therefore when you changed the default value or passed a value via hiera the site was not actually moving to the new port.  This was happening on the linux side.  Added binding info so the behavior is consistent between linux and windows.