### PR TITLE
Updating Splunk Version

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -97,7 +97,7 @@ mod 'puppet-gitlab', '3.0.2'
 mod 'puppet-hiera', '3.3.4'
 mod 'puppet-nginx', '0.16.0'
 mod 'puppet-rabbitmq', '9.0.0'
-# mod 'puppet-splunk', '7.3.0'    # Can't use as 7.3.0 is broken
+mod 'puppet-splunk', '8.0.0'
 mod 'puppet-staging', '3.2.0'
 mod 'puppet-windows_env', '3.2.0'
 mod 'puppet-windows_firewall', '2.0.2'
@@ -119,11 +119,6 @@ mod 'puppetlabs-sshkeys_core', '1.0.2'
 mod 'puppetlabs-selinux_core', '1.0.2'
 mod 'puppetlabs-augeas_core', '1.0.4'
 mod 'puppetlabs-host_core', '1.0.2'
-
-# replaces mod 'puppet-splunk', '7.3.0' until there is a newer release
-mod 'splunk',
-    git: 'https://github.com/voxpupuli/puppet-splunk.git',
-    ref: 'master'
 
 mod 'tse-tse_facts',
     git: 'https://github.com/puppetlabs/tse-module-tse_facts.git',

--- a/site-modules/profile/manifests/infrastructure/splunk/splunk_server.pp
+++ b/site-modules/profile/manifests/infrastructure/splunk/splunk_server.pp
@@ -24,8 +24,8 @@ String            $hec_puppetdetailed_token = '7dc49a8f-8f56-4095-9522-e5566f937
   }
 
   class { 'splunk::params':
-    version  => '7.2.5.1',
-    build    => '962d9a8e1586',
+    version  => '8.0.2.1',
+    build    => 'f002026bad55',
     src_root => 'https://download.splunk.com',
     server   => $splunk_server_fqdn,
   }


### PR DESCRIPTION
Changing splunk version and build information for the Splunk install associated with the splunk_server profile.  Currently is on the 7.x branch, updating to latest Splunk 8 version (8.0.2.1) as of tis date.