### PR TITLE
Removing deprecated app orch definition

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -3,11 +3,6 @@
 # Disable filebucket by default for all File resources:
 File { backup => false }
 
-# Applications managed by App Orchestrator are defined in the site block.
-site {
-
-}
-
 node default {
   # Check if we've set the role for this node via trusted fact, pp_role.  If yes; include that role directly here.
   if !empty( $trusted['extensions']['pp_role'] ) {


### PR DESCRIPTION
Removed the app orch definition because CD4PE (4) control repo manifest check fails with 

```
2020-08-31 10:16:29 UTC: JOB failed with exit code: 1: ---> syntax:manifests
Use of the application-orchestration Site Definition is deprecated. See https://puppet.com/docs/puppet/5.5/deprecated_language.html (file: /repo/manifests/site.pp, line: 7, column: 1)
```