### PR TITLE
Add default ServiceNow credentials

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,6 +4,10 @@ lookup_options:
     convert_to: 'Sensitive'
   '^cd4pe::root_config::ssl_server_private_key$':
     convert_to: 'Sensitive'
+  '^servicenow_reporting_integration::event_management::password$':
+    convert_to: 'Sensitive'
+  '^servicenow_reporting_integration::event_management::oauth_token$':
+    convert_to: 'Sensitive'
 
 ##
 # Hiera

--- a/data/nodes/puppet.classroom.pupppet.com.yaml
+++ b/data/nodes/puppet.classroom.pupppet.com.yaml
@@ -1,0 +1,8 @@
+---
+# Credentials for ServiceNow Reporting Integration
+servicenow_reporting_integration::event_management::user: 'admin'
+servicenow_reporting_integration::event_management::password: 'puppetlabs'
+
+# Credentials for ServiceNow Reporting Integration
+servicenow_cmdb_integration::user: 'admin'
+servicenow_cmdb_integration::password: 'puppetlabs'

--- a/data/nodes/puppet.classroom.pupppet.com.yaml
+++ b/data/nodes/puppet.classroom.pupppet.com.yaml
@@ -1,8 +1,8 @@
 ---
 # Credentials for ServiceNow Reporting Integration
 servicenow_reporting_integration::event_management::user: 'admin'
-servicenow_reporting_integration::event_management::password: 'puppetlabs'
+servicenow_reporting_integration::event_management::password: 'PuppetLabs1'
 
 # Credentials for ServiceNow Reporting Integration
 servicenow_cmdb_integration::user: 'admin'
-servicenow_cmdb_integration::password: 'puppetlabs'
+servicenow_cmdb_integration::password: 'PuppetLabs1'

--- a/site-modules/profile/manifests/platform/baseline/windows/packages.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows/packages.pp
@@ -4,8 +4,8 @@ class profile::platform::baseline::windows::packages {
     provider => chocolatey,
   }
 
-  $packages = [ 'notepadplusplus', '7zip', 'git', 'uniextract' ]
-  package { $packages:
+  $predefined_packages = [ 'notepadplusplus', '7zip', 'git', 'uniextract' ]
+  package { $predefined_packages:
     ensure => present
   }
 


### PR DESCRIPTION
This adds default credentials for ServiceNow integrations for two reasons:
- Prevents having to display the credentials in the PE Web Console
- The `servicenow_reporting_integration` module requires the use of Sensitive parameters for password/oauth_token, which can't be done through the PE UI today.