### PR TITLE
ServiceNow Quebec support

### DIFF
--- a/site-modules/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
+++ b/site-modules/deployments/lib/puppet/functions/deployments/servicenow_change_request.rb
@@ -162,6 +162,7 @@ Puppet::Functions.create_function(:'deployments::servicenow_change_request') do
     # Update Change Request with additional info, and start the approval process
     change_req_url = "#{endpoint}/api/sn_chg_rest/v1/change/normal/#{changereq['result']['sys_id']['value']}?state=assess"
     payload = {}.tap do |data|
+      data[:state] = 'assess'
       data[:risk_impact_analysis] = ia_url + "\n" + report['log'] # rubocop:disable Style/StringConcatenation
       data[:assignment_group] = assignment_group_sys_id
       data[:close_notes] = closenotes.to_json


### PR DESCRIPTION
This PR adds support for the Quebec release of ServiceNow. Without this change, the Change Management integration fails during ticket creation with a `Normal Change Request cannot move to state: assess` error