### PR TITLE
allow for HTTP port change

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -29,6 +29,7 @@ profile::app::redis::bind: 127.0.0.1
 # Sample Website
 profile::app::sample_website::linux::enable_monitoring: false
 profile::app::sample_website::windows::enable_monitoring: false
+profile::app::sample_website::windows::webserver_port : 80
 
 ##
 # Sensu

--- a/site-modules/profile/manifests/app/sample_website/windows.pp
+++ b/site-modules/profile/manifests/app/sample_website/windows.pp
@@ -1,6 +1,6 @@
 class profile::app::sample_website::windows (
   String $doc_root           = 'C:\inetpub\wwwroot\sample_website',
-  Integer $webserver_port    = 80,
+  Integer $webserver_port    = 80,   # change this default value in Hiera common.yaml
   String $apppool            = 'sample_website',
   String $website_source_dir = 'puppet:///modules/profile/app/sample_website',
   Boolean $enable_monitoring = false,
@@ -25,6 +25,12 @@ class profile::app::sample_website::windows (
     ensure          => 'started',
     physicalpath    => $doc_root,
     applicationpool => $apppool,
+    bindings        => [
+      {
+         'bindinginformation'   => "*:$webserver_port:",
+         'protocol'             => 'http',
+      },
+    ],
     require         => [
       Iis_application_pool['sample_website']
     ],
@@ -37,7 +43,7 @@ class profile::app::sample_website::windows (
     enabled      => true,
     protocol     => 'TCP',
     local_port   => $webserver_port,
-    display_name => 'HTTP Inbound',
+    display_name => "HTTP_$webserver_port", # generate a unique inbound rule. this new rule per port value is just for demo purposes
     description  => 'Inbound rule for HTTP Server',
   }
 


### PR DESCRIPTION
Here are the changes:
- updated the iis_site section to allow the specification of the 'webserver_port'
- update the firewall_exception rule to create a unique inbound windows firewall rule for 'every new web server port'. You create a unique firewall rule by using different 'display_name' attribute. Previously the 'display_name' was hard coded. you cannot just replace the port value of an existing inbound firewall rule. You create a unique firewall rule every time or delete & replace a new rule with a new name ('HTTP Port'). We are going with the former choice of just creating a unique firewall rule for every port.
- created a new hiera var for the webserver_port param. this allows us to explain that Hiera is the Data layer, the YAML data front end and the Puppet-code is in the background.