### PR TITLE
Update PE Java Args to increase JVM Memory

### DIFF
--- a/data/nodes/puppet.classroom.puppet.com.yaml
+++ b/data/nodes/puppet.classroom.puppet.com.yaml
@@ -6,3 +6,8 @@ servicenow_reporting_integration::event_management::password: 'PuppetLabs1'
 # Credentials for ServiceNow Reporting Integration
 servicenow_cmdb_integration::user: 'admin'
 servicenow_cmdb_integration::password: 'PuppetLabs1'
+
+# Ensure PuppetDB has enough memory to run
+puppet_enterprise::profile::puppetdb::java_args:
+  Xms: 512m
+  Xmx: 512m


### PR DESCRIPTION
During a recent demo spin up with Hydra, I ran into an issue where Java was consuming 100% CPU cycles for extended periods of time.  Further diagnosis with @kreeuwijk lead to the discovery that the JVM was starved of memory and was spending most of it's time running GC, which caused PE to become completely unresponsive.  Modifying PE JVM memory to 512M from 256M settled things down considerably without impacting stability on the PE master.