### PR TITLE
Update bootstrap.pp

### DIFF
--- a/site-modules/profile/manifests/platform/baseline/windows/bootstrap.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows/bootstrap.pp
@@ -2,7 +2,7 @@ class profile::platform::baseline::windows::bootstrap {
 
   require ::chocolatey
 
-  if versioncmp($::powershell_version, '5.1.0') <= 0 {
+  if versioncmp('5.1.0', $::powershell_version) <= 0 {
     #notify{"version was less than":}
 
     # service needs to be running to install the update


### PR DESCRIPTION
The way the existing bootstrap.pp uses versioncmp and it subsequent operators, bootstrap.pp's values will never be called on a 2016/2019 server with a powershell version higher than 5.1.0.  Adjusting the ordering of versioncmp fixes this problem and correctly places the wuauserv service in started mode on demo's, while placing the required registry keys to keep the patching workflows in place for demonstrating patching in PE.