### PR TITLE
comment CEM modules lines

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -111,8 +111,8 @@ mod 'tse-winntp', '1.0.1'
 mod 'puppet-staging', '3.2.0' 
 
 # CEM modules
-mod 'puppetlabs-cem_linux', :latest
-mod 'puppetlabs-cem_windows', :latest
+#mod 'puppetlabs-cem_linux', :latest
+#mod 'puppetlabs-cem_windows', :latest
 
 
 mod 'demo_cis',


### PR DESCRIPTION
We can't deploy Puppet Code with CEM Modules referenced in the Puppetfile before that the specific Code Manager is applied to the Puppet Server.
We need to comment the lines and then add a step in github action to push the Puppetfile with the lines uncomment
