### PR TITLE
Removedsc

### DIFF
--- a/site-modules/profile/manifests/platform/baseline/windows.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows.pp
@@ -1,6 +1,6 @@
 class profile::platform::baseline::windows {
 
-  # include ::profile::platform::baseline::windows::bootstrap
+  include ::profile::platform::baseline::windows::bootstrap
   include ::profile::platform::baseline::windows::common
   include ::profile::platform::baseline::windows::motd
   include ::profile::platform::baseline::windows::firewall

--- a/site-modules/profile/manifests/platform/baseline/windows/bootstrap.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows/bootstrap.pp
@@ -2,36 +2,31 @@ class profile::platform::baseline::windows::bootstrap {
 
   require ::chocolatey
 
-  if versioncmp('5.1.0', $::powershell_version) <= 0 {
-    #notify{"version was less than":}
+  # service needs to be running to install the update
+  service { 'wuauserv':
+    ensure => 'running',
+    enable => true,
+  }
 
-    # service needs to be running to install the update
-    service { 'wuauserv':
-      ensure => 'running',
-      enable => true,
-    }
+  # disable auto updating so machine doesnt start downloading / updating
+  registry::value { 'disable updates':
+    key   => 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU',
+    value => 'NoAutoUpdate',
+    data  => '1',
+    type  => 'dword',
+  }
 
-    # disable auto updating so machine doesnt start downloading / updating
-    registry::value { 'disable updates':
-      key   => 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU',
-      value => 'NoAutoUpdate',
-      data  => '1',
-      type  => 'dword',
-    }
+  # Get WMF
+  package { 'powershell':
+    ensure   => latest,
+    #install_options => ['-pre','--ignore-package-exit-codes'],
+    provider => chocolatey,
+  }
 
-    # Get WMF
-    package { 'powershell':
-      ensure   => latest,
-      #install_options => ['-pre','--ignore-package-exit-codes'],
-      provider => chocolatey,
-    }
-
-    reboot {'dsc_install':
-      subscribe => Package['powershell'],
-      apply     => 'immediately',
-      timeout   => 0,
-    }
-
+  reboot {'dsc_install':
+    subscribe => Package['powershell'],
+    apply     => 'immediately',
+    timeout   => 0,
   }
 
   registry::value { 'enable insecure winrm':


### PR DESCRIPTION
Same fix as I did in the Deimos private repo; I forgot we don't need the private repo any more.  This should completely fix the versioncmp error and unhides the resources it was protecting that are needed for Windows patching.