### PR TITLE
update ruby setup

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,13 +15,12 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
-    - name: Install bundler and gems
-      run: |
-        gem install bundler -v 2.2.9
-        bundle install --jobs 4 --retry 3
+        bundler: latest
+    - name: Install gems
+      run: bundle install --jobs 4 --retry 3
     - name: Run sytax check
       run: bundle exec rake syntax
     # - name: Run Onceover

--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,12 @@ group :development do
   gem 'onceover', '3.20.0'
   gem 'onceover-codequality', '0.8.0'
   gem 'pry'
-  gem 'rake', '12.3.3'
+  gem 'rake', '13.0.6'
   gem 'ra10ke'
   gem 'rest-client'
-  gem 'puppet', '6.25.1'
-  gem 'puppet-syntax', '3.1.0'
-  gem 'fast_gettext', '~> 1.1'
+  gem 'puppet', '6.28.0'
+  gem 'puppet-syntax', '3.2.1'
+  gem 'fast_gettext', '2.2.0'
   # gem 'rspec', '3.8.0'
   # gem 'rspec-core', '3.8.0'
   # gem 'rspec-mocks', '=3.8.1'
@@ -22,8 +22,8 @@ group :development do
   # gem 'facter', '2.5.7'
   gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem 'rubocop', '1.6.1'
-  gem 'rubocop-rspec', '2.0.1'
+  gem 'rubocop', '1.39.0'
+  gem 'rubocop-rspec', '2.15.0'
   # gem 'puppetlabs_spec_helper'
   # gem 'puppet-syntax'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :development do
   gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
   gem 'rubocop', '1.6.1'
-  gem 'rubocop-rspec', '2.4.0'
+  gem 'rubocop-rspec', '2.0.1'
   # gem 'puppetlabs_spec_helper'
   # gem 'puppet-syntax'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ group :development do
   # gem 'facter', '2.5.7'
   gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem 'rubocop', '1.39.0'
-  gem 'rubocop-rspec', '2.15.0'
+  gem 'rubocop', '1.6.1'
+  gem 'rubocop-rspec', '2.4.0'
   # gem 'puppetlabs_spec_helper'
   # gem 'puppet-syntax'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem 'rest-client'
   gem 'puppet', '6.28.0'
   gem 'puppet-syntax', '3.2.1'
-  gem 'fast_gettext', '2.2.0'
+  gem 'fast_gettext', '~> 1.1'
   # gem 'rspec', '3.8.0'
   # gem 'rspec-core', '3.8.0'
   # gem 'rspec-mocks', '=3.8.1'


### PR DESCRIPTION
The ruby-setup action previously being used has been decommed and transitioned to the official ruby.org ruby-setup.  This ruby-setup includes a built-in to install bundler, so changed syntax to leverage that.  Also bumped gems to latest version.