### PR TITLE
remove legacy facts and top-scoped facts

### DIFF
--- a/site-modules/example/manifests/wordpress.pp
+++ b/site-modules/example/manifests/wordpress.pp
@@ -9,9 +9,9 @@ class example::wordpress {
     ensure => present,
   }
 
-  apache::vhost { $::fqdn:
+  apache::vhost { $facts['networking']['fqdn']:
     priority   => '10',
-    vhost_name => $::fqdn,
+    vhost_name => $facts['networking']['fqdn'],
     port       => '80',
     docroot    => '/var/www/html',
   }

--- a/site-modules/profile/manifests/app/cloudshop.pp
+++ b/site-modules/profile/manifests/app/cloudshop.pp
@@ -1,6 +1,6 @@
 class profile::app::cloudshop {
 
-  case $::kernel {
+  case $facts['kernel'] {
     'windows': {
       include profile::app::cloudshop::sqlserver::init
       include profile::app::cloudshop::webapp::db

--- a/site-modules/profile/manifests/app/cloudshop/sqlserver/attachdb.pp
+++ b/site-modules/profile/manifests/app/cloudshop/sqlserver/attachdb.pp
@@ -31,15 +31,15 @@ define profile::app::cloudshop::sqlserver::attachdb (
     subscribe => Staging::File[$zip_file],
   }
   exec { "Attach ${title}":
-    command  => "import-module \'${sqlps_path}\'; invoke-sqlcmd \"USE [master] CREATE DATABASE [${title}] ON (FILENAME = \'${data_path}\\${mdf_file}\'),(FILENAME = \'${data_path}\\${ldf_file}\') for ATTACH\" -QueryTimeout 3600  -username \'sa\' -password \'${profile::app::cloudshop::sqlserver::sql::sa_pass}\' -ServerInstance \'${::hostname}\\${dbinstance}\'",
+    command  => "import-module \'${sqlps_path}\'; invoke-sqlcmd \"USE [master] CREATE DATABASE [${title}] ON (FILENAME = \'${data_path}\\${mdf_file}\'),(FILENAME = \'${data_path}\\${ldf_file}\') for ATTACH\" -QueryTimeout 3600  -username \'sa\' -password \'${profile::app::cloudshop::sqlserver::sql::sa_pass}\' -ServerInstance \'${facts['networking']['hostname']}\\${dbinstance}\'",
     provider => powershell,
     path     => $sqlps_path,
-    unless   => "import-module \'${sqlps_path}\'; if(invoke-sqlcmd -Query \"select [name] from sys.databases where [name] = \'${title}\';\" -ServerInstance \"${::hostname}\\${dbinstance}\") { exit 0 } else { exit 1 }",
+    unless   => "import-module \'${sqlps_path}\'; if(invoke-sqlcmd -Query \"select [name] from sys.databases where [name] = \'${title}\';\" -ServerInstance \"${facts['networking']['hostname']}\\${dbinstance}\") { exit 0 } else { exit 1 }",
   }
   exec { "Change owner of ${title}":
-    command   => "import-module \'${sqlps_path}\'; invoke-sqlcmd \"USE [${title}] ALTER AUTHORIZATION ON DATABASE::${title} TO ${owner};\" -QueryTimeout 3600 -username \'sa\' -password \'${profile::app::cloudshop::sqlserver::sql::sa_pass}\' -ServerInstance \'${::hostname}\\${dbinstance}\'",
+    command   => "import-module \'${sqlps_path}\'; invoke-sqlcmd \"USE [${title}] ALTER AUTHORIZATION ON DATABASE::${title} TO ${owner};\" -QueryTimeout 3600 -username \'sa\' -password \'${profile::app::cloudshop::sqlserver::sql::sa_pass}\' -ServerInstance \'${facts['networking']['hostname']}\\${dbinstance}\'",
     provider  => powershell,
-    unless    => "import-module \'${sqlps_path}\'; if(invoke-sqlcmd -Query \"select suser_sname(owner_sid) from sys.databases where [name] = \'${title}\';\" -ServerInstance \"${::hostname}\\${dbinstance}\" | where-object \"Column1\" -eq \"${owner}\") { exit 0 } else { exit 1 }",
+    unless    => "import-module \'${sqlps_path}\'; if(invoke-sqlcmd -Query \"select suser_sname(owner_sid) from sys.databases where [name] = \'${title}\';\" -ServerInstance \"${facts['networking']['hostname']}\\${dbinstance}\" | where-object \"Column1\" -eq \"${owner}\") { exit 0 } else { exit 1 }",
     subscribe => Exec["Attach ${title}"],
   }
   sqlserver::login{ $owner:

--- a/site-modules/profile/manifests/app/cloudshop/webapp/db.pp
+++ b/site-modules/profile/manifests/app/cloudshop/webapp/db.pp
@@ -3,7 +3,7 @@ class profile::app::cloudshop::webapp::db (
   $dbpass        = 'Azure$123',
   $dbuser        = 'CloudShop',
   $dbname        = 'AdventureWorks2012',
-  $dbserver      = $::hostname, # $::fqdn doesn't work on Windows / AWS
+  $dbserver      = $fact['networking']['hostname'],
   $file_source   = 'https://s3-us-west-2.amazonaws.com/tseteam/files/sqlwebapp',
 ){
   profile::app::cloudshop::sqlserver::attachdb { $dbname:

--- a/site-modules/profile/manifests/app/cloudshop/webapp/iis.pp
+++ b/site-modules/profile/manifests/app/cloudshop/webapp/iis.pp
@@ -2,20 +2,12 @@
 # Server 2012. This will be useful for apps connecting to a database.
 class profile::app::cloudshop::webapp::iis {
 
-  if Integer($::operatingsystemrelease[0,4]) >= 2016 {
-    $app_server_features = [
+  $app_server_features = [
       'WAS',
       'WAS-Process-Model',
       'WAS-NET-Environment',
       'WAS-Config-APIs',
-    ]
-  } else {
-    $app_server_features = [
-      'Application-Server',
-      'AS-NET-Framework',
-      'AS-Web-Support',
-    ]
-  }
+  ]
 
   $iis_features = [
       'Web-Server',

--- a/site-modules/profile/manifests/app/cloudshop/webapp/init.pp
+++ b/site-modules/profile/manifests/app/cloudshop/webapp/init.pp
@@ -1,5 +1,5 @@
 class profile::app::cloudshop::webapp::init (
-  $dbserver      = $::hostname, # on Windows / AWS. $::fqdn doesn't work
+  $dbserver      = $facts['netowrking']['hostname'],
   $dbinstance    = 'MYINSTANCE',
   $dbpass        = 'Azure$123',
   $dbuser        = 'CloudShop',

--- a/site-modules/profile/manifests/app/db/mysql/client.pp
+++ b/site-modules/profile/manifests/app/db/mysql/client.pp
@@ -1,6 +1,6 @@
 class profile::app::db::mysql::client {
 
-  case $::facts['kernel'] {
+  case $facts['kernel'] {
     'windows': {
       fail('Unsupported OS')
     }

--- a/site-modules/profile/manifests/app/db/mysql/server.pp
+++ b/site-modules/profile/manifests/app/db/mysql/server.pp
@@ -1,6 +1,6 @@
 class profile::app::db::mysql::server {
 
-  case $::facts['kernel'] {
+  case $facts['kernel'] {
     'windows': {
       fail('Unsupported OS')
     }

--- a/site-modules/profile/manifests/app/docker.pp
+++ b/site-modules/profile/manifests/app/docker.pp
@@ -1,6 +1,6 @@
 class profile::app::docker {
 
-  if $::kernel == 'windows' {
+  if $facts['kernel'] == 'windows' {
     fail('Unsupported OS')
   }
 

--- a/site-modules/profile/manifests/app/entropy.pp
+++ b/site-modules/profile/manifests/app/entropy.pp
@@ -1,6 +1,6 @@
 class profile::app::entropy {
 
-  if $::kernel == 'windows' {
+  if $facts['kernel'] == 'windows' {
     fail('Unsupported OS')
   }
 

--- a/site-modules/profile/manifests/app/haproxy.pp
+++ b/site-modules/profile/manifests/app/haproxy.pp
@@ -1,11 +1,11 @@
 class profile::app::haproxy {
 
-  if $::kernel == 'windows' {
+  if $facts['kernel'] == 'windows' {
     fail('Unsupported OS')
   }
 
   # Use at least 1.5 on all platforms
-  if $::facts['os']['name'] == 'Ubuntu' {
+  if $facts['os']['name'] == 'Ubuntu' {
 
     include ::apt
 
@@ -21,7 +21,7 @@ class profile::app::haproxy {
 
   class { '::haproxy':
     global_options   => {
-      'log'     => "${::ipaddress} local0",
+      'log'     => "${facts['networking']['ip']} local0",
       'chroot'  => '/var/lib/haproxy',
       'pidfile' => '/var/run/haproxy.pid',
       'maxconn' => '4000',

--- a/site-modules/profile/manifests/app/java.pp
+++ b/site-modules/profile/manifests/app/java.pp
@@ -2,7 +2,7 @@ class profile::app::java (
   $distribution = 'jre',
 ){
 
-  case $::kernel {
+  case $facts['kernel'] {
 
     'windows': {
       class{'::profile::app::java::windows':

--- a/site-modules/profile/manifests/app/jenkins/master.pp
+++ b/site-modules/profile/manifests/app/jenkins/master.pp
@@ -1,6 +1,6 @@
 class profile::app::jenkins::master {
 
-  if $::kernel == 'windows' {
+  if $facts['kernel'] == 'windows' {
     fail('Unsupported OS')
   }
 

--- a/site-modules/profile/manifests/app/jenkins/slave.pp
+++ b/site-modules/profile/manifests/app/jenkins/slave.pp
@@ -4,7 +4,7 @@ class profile::app::jenkins::slave (
 
   include ::profile::platform::baseline
 
-  case $::kernel {
+  case $facts['kernel'] {
 
     'Linux': {
       class { '::jenkins::slave':

--- a/site-modules/profile/manifests/app/jenkins/win_slave.pp
+++ b/site-modules/profile/manifests/app/jenkins/win_slave.pp
@@ -20,7 +20,7 @@ class profile::app::jenkins::win_slave (
   $executors_flag   = "-executors ${executors}"
   $ui_user_flag     = "-username ${ui_user}"
   $ui_pass_flag     = "-password ${ui_pass}"
-  $slave_alias_flag = "-name ${::fqdn}"
+  $slave_alias_flag = "-name ${facts['networking']['fqdn']}"
   $master_url_flag  = "-master ${masterurl}"
   $labels_flag      = "-labels ${labels}"
 

--- a/site-modules/profile/manifests/app/nagios/server.pp
+++ b/site-modules/profile/manifests/app/nagios/server.pp
@@ -64,8 +64,8 @@ class profile::app::nagios::server {
     subscribe => File['/etc/httpd/conf.d/nagios.conf'],
   }
 
-  @@host { $::fqdn:
-    ip => $::ipaddress,
+  @@host { $facts['networking']['fqdn']:
+    ip => $facts['networking']['ip'],
   }
 
   Host <<||>>

--- a/site-modules/profile/manifests/app/nagios/target.pp
+++ b/site-modules/profile/manifests/app/nagios/target.pp
@@ -2,22 +2,22 @@ class profile::app::nagios::target {
 
   # add hostname/ip exported resrouce here for server to collect
 
-  @@host { $::fqdn:
-    ip => $::ipaddress,
+  @@host { $facts['networking']['fqdn']:
+    ip => $facts['networking']['ip'],
   }
 
-  @@nagios_host { $::fqdn:
+  @@nagios_host { $facts['networking']['fqdn']:
     ensure  => present,
-    alias   => $::hostname,
-    address => $::ipaddress,
+    alias   => $facts['networking']['hostname'],
+    address => $facts['networking']['ip'],
     use     => 'linux-server',
   }
-  @@nagios_service { "check_ping_${::hostname}":
+  @@nagios_service { "check_ping_${facts['networking']['hostname']}":
     check_command       => 'check_ping!100.0,20%!500.0,60%',
     use                 => 'generic-service',
-    host_name           => $::fqdn,
+    host_name           => $facts['networking']['fqdn'],
     notification_period => '24x7',
-    service_description => "${::hostname}_check_ping",
+    service_description => "${facts['networking']['hostname']}_check_ping",
   }
 
   Host <<||>>

--- a/site-modules/profile/manifests/app/puppet_tomcat.pp
+++ b/site-modules/profile/manifests/app/puppet_tomcat.pp
@@ -26,7 +26,7 @@ class profile::app::puppet_tomcat (
 
   }
 
-  if $::kernel == 'Linux' {
+  if $facts['kernel'] == 'Linux' {
 
       class {'::profile::app::puppet_tomcat::linux':
         deploy_sample_app     => $deploy_sample_app,
@@ -37,7 +37,7 @@ class profile::app::puppet_tomcat (
       }
 
     }
-    elsif $::kernel == 'windows' {
+    elsif $facts['kernel'] == 'windows' {
 
       class {'::profile::app::puppet_tomcat::windows':
         deploy_sample_app     => $deploy_sample_app,

--- a/site-modules/profile/manifests/app/puppet_webapp/webhead.pp
+++ b/site-modules/profile/manifests/app/puppet_webapp/webhead.pp
@@ -2,7 +2,7 @@ class profile::app::puppet_webapp::webhead (
   $app_name    = 'webui',
   $app_version = '0.1.12',
   $dist_file   = "https://github.com/ipcrm/puppet_webapp/releases/download/${app_version}/puppet_webapp-${app_version}.tar.gz",
-  $vhost_name  = $::fqdn,
+  $vhost_name  = $facts['networking']['fqdn'],
   $vhost_port  = '8008',
   $doc_root    = '/var/www/flask',
   $app_env     = pick_default($::appenv,'dev')
@@ -18,7 +18,7 @@ class profile::app::puppet_webapp::webhead (
     app_env     => $app_env,
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
 
     'Debian': {
       class {'::profile::app::puppet_webapp::webhead::ubuntu':

--- a/site-modules/profile/manifests/app/puppet_webapp/webhead/rhel.pp
+++ b/site-modules/profile/manifests/app/puppet_webapp/webhead/rhel.pp
@@ -2,7 +2,7 @@ class profile::app::puppet_webapp::webhead::rhel (
   $app_name = 'webui',
   $app_version = '0.1.12',
   $dist_file = "https://github.com/ipcrm/puppet_webapp/releases/download/${app_version}/puppet_webapp-${app_version}.tar.gz",
-  $vhost_name = $::fqdn,
+  $vhost_name = $facts['networking']['fqdn'],
   $vhost_port = '8008',
   $doc_root = '/var/www/flask',
   $app_env  = pick_default($::appenv,'dev')
@@ -95,11 +95,11 @@ class profile::app::puppet_webapp::webhead::rhel (
     action => accept,
   }
 
-  @@haproxy::balancermember { "haproxy-${::fqdn}":
+  @@haproxy::balancermember { "haproxy-${facts['networking']['fqdn']}":
     listening_service => "${app_env}_bk",
     ports             => $vhost_port,
-    server_names      => $::hostname,
-    ipaddresses       => $::ipaddress,
+    server_names      => $facts['networking']['hostname'],
+    ipaddresses       => $facts['networking']['ip'],
     options           => 'check',
   }
 

--- a/site-modules/profile/manifests/app/puppet_webapp/webhead/ubuntu.pp
+++ b/site-modules/profile/manifests/app/puppet_webapp/webhead/ubuntu.pp
@@ -2,7 +2,7 @@ class profile::app::puppet_webapp::webhead::ubuntu (
   $app_name = 'webui',
   $app_version = '0.1.12',
   $dist_file = "https://github.com/ipcrm/puppet_webapp/releases/download/${app_version}/puppet_webapp-${app_version}.tar.gz",
-  $vhost_name = $::fqdn,
+  $vhost_name = $facts['networking']['fqdn'],
   $vhost_port = '8008',
   $doc_root = '/var/www/flask',
   $app_env  = pick_default($::appenv,'dev')
@@ -85,11 +85,11 @@ class profile::app::puppet_webapp::webhead::ubuntu (
     action => accept,
   }
 
-  @@haproxy::balancermember { "haproxy-${::fqdn}":
+  @@haproxy::balancermember { "haproxy-${facts['networking']['fqdn']}":
     listening_service => "${app_env}_bk",
     ports             => $vhost_port,
-    server_names      => $::hostname,
-    ipaddresses       => $::ipaddress,
+    server_names      => $facts['networking']['hostname'],
+    ipaddresses       => $facts['networking']['ip'],
     options           => 'check',
   }
 

--- a/site-modules/profile/manifests/app/puppetdev.pp
+++ b/site-modules/profile/manifests/app/puppetdev.pp
@@ -1,6 +1,6 @@
 class profile::app::puppetdev {
 
-  case $::kernel {
+  case $facts['kernel'] {
 
     'windows': {
       contain ::profile::app::puppetdev::windows

--- a/site-modules/profile/manifests/app/puppetdev/linux.pp
+++ b/site-modules/profile/manifests/app/puppetdev/linux.pp
@@ -1,7 +1,7 @@
 class profile::app::puppetdev::linux {
   include git
 
-  $dev_packages = $::osfamily ? {
+  $dev_packages = $facts['os']['family'] ? {
     'RedHat' => [
       'binutils',
       'bzip2',

--- a/site-modules/profile/manifests/app/rgbank.pp
+++ b/site-modules/profile/manifests/app/rgbank.pp
@@ -1,6 +1,6 @@
 class profile::app::rgbank {
 
-  if $::osfamily != 'RedHat' {
+  if $facts['os']['family'] != 'RedHat' {
     fail('Unsupported OS')
   }
 
@@ -21,7 +21,7 @@ class profile::app::rgbank {
   }
 
   $default = {
-    'host' => $::fqdn,
+    'host' => $facts['networking']['fqdn'],
     'port' => 8888,
     'ip'   => '127.0.0.1',
   }

--- a/site-modules/profile/manifests/app/sample_website.pp
+++ b/site-modules/profile/manifests/app/sample_website.pp
@@ -1,7 +1,7 @@
 # @summary This profile installs a sample website
 class profile::app::sample_website {
 
-  case $::kernel {
+  case $facts['kernel'] {
     'windows': { include profile::app::sample_website::windows }
     'Linux':   { include profile::app::sample_website::linux }
     default:   {

--- a/site-modules/profile/manifests/app/sample_website/linux.pp
+++ b/site-modules/profile/manifests/app/sample_website/linux.pp
@@ -14,7 +14,7 @@ class profile::app::sample_website::linux (
   }
 
   # configure apache
-  apache::vhost { $::fqdn:
+  apache::vhost { $facts['networking']['fqdn']:
     port            => $webserver_port,
     docroot         => $doc_root,
     require         => File[$doc_root],

--- a/site-modules/profile/manifests/app/sensu/handlers.pp
+++ b/site-modules/profile/manifests/app/sensu/handlers.pp
@@ -28,7 +28,7 @@ class profile::app::sensu::handlers (
     type    => 'pipe',
     command => 'handler-mailer.rb',
     config  => {
-      admin_gui => "http://${::fqdn}:3000",
+      admin_gui => "http://${facts['networking']['fqdn']}:3000",
       mail_from => $mailer_from,
       mail_to   => $mailer_to,
     },

--- a/site-modules/profile/manifests/app/webserver/apache.pp
+++ b/site-modules/profile/manifests/app/webserver/apache.pp
@@ -2,11 +2,11 @@ class profile::app::webserver::apache (
   $default_vhost = true,
 ){
 
-  if $::kernel == 'windows' {
+  if $facts['kernel'] == 'windows' {
     fail('Unsupported OS')
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian':{
       $mpm = 'itk'
     }

--- a/site-modules/profile/manifests/app/webserver/iis.pp
+++ b/site-modules/profile/manifests/app/webserver/iis.pp
@@ -2,7 +2,7 @@ class profile::app::webserver::iis (
   Boolean $default_website = true,
 ){
 
-  if $::kernel != 'windows' {
+  if $facts['kernel'] != 'windows' {
     fail('Unsupported OS')
   }
 

--- a/site-modules/profile/manifests/app/webserver/nginx.pp
+++ b/site-modules/profile/manifests/app/webserver/nginx.pp
@@ -2,7 +2,7 @@ class profile::app::webserver::nginx(
   Boolean $php = false,
 ){
 
-  if $::kernel == 'windows' {
+  if $facts['kernel'] == 'windows' {
     fail('Unsupported OS')
   }
 

--- a/site-modules/profile/manifests/platform/baseline/linux/packages.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/packages.pp
@@ -5,7 +5,7 @@ class profile::platform::baseline::linux::packages {
 
   ensure_packages($pkgs, {ensure => installed})
 
-  if $::osfamily == 'RedHat' {
+  if $facts['os']['family'] == 'RedHat' {
     include ::epel
   }
 

--- a/site-modules/profile/manifests/platform/baseline/linux/vim.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/vim.pp
@@ -6,7 +6,7 @@ class profile::platform::baseline::linux::vim {
     'root'  => '/root',
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian': {
       $package = 'vim-nox'
     }

--- a/site-modules/profile/manifests/platform/compliance/hipaa.pp
+++ b/site-modules/profile/manifests/platform/compliance/hipaa.pp
@@ -1,6 +1,6 @@
 class profile::platform::compliance::hipaa {
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'windows': {
       include ::profile::platform::compliance::hipaa::windows
     }

--- a/site-modules/profile/manifests/puppet/master/gen_certs.pp
+++ b/site-modules/profile/manifests/puppet/master/gen_certs.pp
@@ -1,6 +1,6 @@
 class profile::puppet::master::gen_certs (
   $dns_alt_names = ['puppet','puppetpoc'],
-  $cert_hostname = $::fqdn,
+  $cert_hostname = $facts['networking']['fqdn'],
 ){
 
 

--- a/site-modules/profile/manifests/puppet/master/gitea.pp
+++ b/site-modules/profile/manifests/puppet/master/gitea.pp
@@ -27,9 +27,9 @@ class profile::puppet::master::gitea {
       service_mode           => '0644',
       configuration_sections => {
         'server'     => {
-          'DOMAIN'           => $::fqdn,
+          'DOMAIN'           => $facts['networking']['fqdn'],
           'HTTP_PORT'        => 3000,
-          'ROOT_URL'         => "https://${::fqdn}/",
+          'ROOT_URL'         => "https://${facts['networking']['fqdn']}/",
           'HTTP_ADDR'        => '0.0.0.0',
           'DISABLE_SSH'      => false,
           'SSH_PORT'         => '22',

--- a/site-modules/profile/manifests/puppet/master/se_gitbook.pp
+++ b/site-modules/profile/manifests/puppet/master/se_gitbook.pp
@@ -36,7 +36,7 @@ class profile::puppet::master::se_gitbook (
     cleanup      => true,
   }
 
-  apache::vhost { $::fqdn:
+  apache::vhost { $facts['networking']['fqdn']:
     port    => $gitbook_port,
     docroot => $gitbook_wwwroot,
   }

--- a/site-modules/profile/manifests/puppet/orch_agent.pp
+++ b/site-modules/profile/manifests/puppet/orch_agent.pp
@@ -2,7 +2,7 @@ class profile::puppet::orch_agent (
   Boolean $ensure = false,
 )
 {
-  $puppet_conf = $::kernel ? {
+  $puppet_conf = $facts['kernel'] ? {
     'windows' => 'C:/ProgramData/PuppetLabs/puppet/etc/puppet.conf',
     default   => '/etc/puppetlabs/puppet/puppet.conf',
   }

--- a/site-modules/profile/manifests/puppet/seteam_master.pp
+++ b/site-modules/profile/manifests/puppet/seteam_master.pp
@@ -1,6 +1,6 @@
 class profile::puppet::seteam_master {
 
-  if $::facts['kernel'] != 'Linux' {
+  if $facts['kernel'] != 'Linux' {
     fail('Unsupported OS!')
   }
 

--- a/site-modules/profile/templates/app/403.html.epp
+++ b/site-modules/profile/templates/app/403.html.epp
@@ -10,12 +10,12 @@
 <body>
     <div class="container">
         <div class="blurb">
-          <% if $::kernel == 'windows' { -%>
-            <img src="img/windows.png" height="128" width="128" />
-          <% } elsif $::kernel == 'Linux' { -%>
-            <img src="img/tux.png" height="128" width="128" />
-            <% } elsif $::kernel == 'Darwin' { -%>
-              <img src="img/apple.png" height="128" width="128" />
+          <% if $facts['kernel'] == 'windows' { -%>
+            <img src="img/windows.png" height="128" width="128" alt="Windows" />
+          <% } elsif $facts['kernel'] == 'Linux' { -%>
+            <img src="img/tux.png" height="128" width="128" alt="Linux" />
+            <% } elsif $facts['kernel'] == 'Darwin' { -%>
+              <img src="img/apple.png" height="128" width="128" alt="MacOS" />
             <% } -%>
             <h1 class="error">403 Forbidden Error</h1>
         </div>

--- a/site-modules/profile/templates/app/404.html.epp
+++ b/site-modules/profile/templates/app/404.html.epp
@@ -10,12 +10,12 @@
 <body>
     <div class="container">
         <div class="blurb">
-          <% if $::kernel == 'windows' { -%>
-            <img src="img/windows.png" height="128" width="128" />
-          <% } elsif $::kernel == 'Linux' { -%>
-            <img src="img/tux.png" height="128" width="128" />
-            <% } elsif $::kernel == 'Darwin' { -%>
-              <img src="img/apple.png" height="128" width="128" />
+          <% if $facts['kernel'] == 'windows' { -%>
+            <img src="img/windows.png" height="128" width="128" alt="Windows" />
+          <% } elsif $facts['kernel'] == 'Linux' { -%>
+            <img src="img/tux.png" height="128" width="128" alt="Linux" />
+            <% } elsif $facts['kernel'] == 'Darwin' { -%>
+              <img src="img/apple.png" height="128" width="128" alt="MacOS" />
             <% } -%>
             <h1 class="error">404 Not Found Error</h1>
         </div>

--- a/site-modules/profile/templates/app/sample_website.html.epp
+++ b/site-modules/profile/templates/app/sample_website.html.epp
@@ -19,7 +19,7 @@
             <% } -%>
             <h1>System Info </h1>
             <p>fqdn/certname:
-                <%= $::trusted[certname] %>
+                <%= $trusted['certname'] %>
             </p>
             <p>ip address:
                 <%= $facts['networking']['ip'] %>

--- a/site-modules/profile/templates/app/sample_website.html.epp
+++ b/site-modules/profile/templates/app/sample_website.html.epp
@@ -10,22 +10,22 @@
 <body>
     <div class="container">
         <div class="blurb">
-          <% if $::kernel == 'windows' { -%>
-            <img src="img/windows.png" height="128" width="128" />
-          <% } elsif $::kernel == 'Linux' { -%>
-            <img src="img/tux.png" height="128" width="128" />
-            <% } elsif $::kernel == 'Darwin' { -%>
-              <img src="img/apple.png" height="128" width="128" />
+          <% if $facts['kernel'] == 'windows' { -%>
+            <img src="img/windows.png" height="128" width="128" alt="Windows" />
+          <% } elsif $facts['kernel'] == 'Linux' { -%>
+            <img src="img/tux.png" height="128" width="128" alt="Linux" />
+            <% } elsif $facts['kernel'] == 'Darwin' { -%>
+              <img src="img/apple.png" height="128" width="128" alt="MacOS" />
             <% } -%>
             <h1>System Info </h1>
             <p>fqdn/certname:
                 <%= $::trusted[certname] %>
             </p>
             <p>ip address:
-                <%= $::networking[ip] %>
+                <%= $facts['networking']['ip'] %>
             </p>
             <p>total system memory:
-                <%= $::memory[system][total] %>
+                <%= $facts['memory']['system']['total'] %>
             </p>
         </div>
     </div>

--- a/site-modules/role/functions/require_kernel.pp
+++ b/site-modules/role/functions/require_kernel.pp
@@ -2,7 +2,7 @@ function role::require_kernel(
   String[1] $kernel,
 ) {
 
-  if $::facts['kernel'] != $kernel {
+  if $facts['kernel'] != $kernel {
     fail('Unsupported OS!')
   }
 


### PR DESCRIPTION
I got inspired by the Hackathon yesterday.  This cleans up all legacy facts and top-scope facts ($::factname or $::facts[factname]) and follows the style guide suggestions of quoting.