### PR TITLE
remove gcc package, switch baseline/packages to hiera

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -27,7 +27,6 @@ mod 'puppetlabs-docker', '4.1.0'
 mod 'puppetlabs-exec', '0.8.0'
 mod 'puppetlabs-facter_task', '0.7.0'
 mod 'puppetlabs-firewall', '3.2.0'
-mod 'puppetlabs-gcc', '0.3.0' # Needs updated to support stdlib 6.5
 mod 'puppetlabs-git', '0.5.0'
 mod 'puppetlabs-haproxy', '4.3.0'
 mod 'puppetlabs-hocon', '1.1.0'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -94,6 +94,9 @@ device_manager::devices:
       ssl: false
 
 profile::platform::baseline::enable_monitoring: false
+profile::platform::baseline::linux::packages::pkgs:
+  - wget
+  - unzip
 
 ##
 # Puppet Enterprise

--- a/site-modules/profile/manifests/app/sensu/plugins.pp
+++ b/site-modules/profile/manifests/app/sensu/plugins.pp
@@ -1,22 +1,27 @@
 #
 class profile::app::sensu::plugins (
   Array $plugin_list,
-)
-{
-  if $facts['os']['family'] != 'windows' {
-    include gcc
+){
+  case $facts['os']['family'] {
+    'RedHat': {
+      $packages = ['gcc', 'gcc-c++']
 
-    Package {
-      ensure  => 'installed',
-      provider => sensu_gem,
+      package { $packages:
+        ensure   => 'installed',
+        provider => sensu_gem,
+      }
+      package { $plugin_list:
+        require  => Class['gcc']
+      }
     }
-    package { $plugin_list:
-      require  => Class['gcc']
+    'windows': {
+      package { ['sensu-plugins-windows','sensu-plugins-http']:
+        ensure   => 'installed',
+        provider => sensu_gem
+      }
     }
-  } else {
-    package {['sensu-plugins-windows','sensu-plugins-http']:
-      ensure   => 'installed',
-      provider => sensu_gem
+    default: {
+      fail("Class['profile::app::sensu::plugins']: Unsupported OS Family: ${facts['os']['family']}")
     }
   }
 }

--- a/site-modules/profile/manifests/platform/baseline/linux/packages.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/packages.pp
@@ -1,13 +1,13 @@
 # @summary This profile installs unzip and git as part of the Linux baseline
-class profile::platform::baseline::linux::packages {
-
-  $pkgs = ['unzip','wget']
-
-  ensure_packages($pkgs, {ensure => installed})
+class profile::platform::baseline::linux::packages (
+  Array[String] $pkgs
+){
 
   if $::osfamily == 'RedHat' {
     include ::epel
   }
+
+  ensure_packages($pkgs, {ensure => installed})
 
   unless getvar('trusted.external.servicenow.u_enforced_packages').empty {
     $packages = parsejson($trusted['external']['servicenow']['u_enforced_packages'])


### PR DESCRIPTION
A couple of pretty small ones...
* Get rid of the puppetlabs-gcc module which has been removed from the Forge
* Change the baseline/linux/packages.pp to leverage hiera rather than hardcoded packages.  Primary idea is to move towards style guide and best practices.