### PR TITLE
Update bootstrap.pp to comment out the wuauserv service from running

### DIFF
--- a/site-modules/profile/manifests/platform/baseline/windows/bootstrap.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows/bootstrap.pp
@@ -4,7 +4,7 @@ class profile::platform::baseline::windows::bootstrap {
 
   # service needs to be running to install the update
   service { 'wuauserv':
-    ensure => 'running',
+    #ensure => 'running',
     enable => true,
   }
 


### PR DESCRIPTION
This is to fix the issue where the Windows Update service is restarted as a corrective change periodically.  Background: The Windows Update service automatically stops itself after it checks for updates and should remain stopped until triggered by other processes.