### PR TITLE
add OS hiera level, put Ubuntu/cron there

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-        rubygems: 3.1
+        rubygems: default
         bundler: latest
     - name: Install gems
       run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-        rubygems: latest
+        rubygems: 3.1
         bundler: latest
     - name: Install gems
       run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/repotest.yml
+++ b/.github/workflows/repotest.yml
@@ -18,13 +18,6 @@ jobs:
           head_to_merge: master
           target_branch: production
           github_token: ${{ github.token }}
-      - name: Merge master -> development
-        uses: devmasx/merge-branch@v1.3.0
-        with:
-          type: now
-          head_to_merge: master
-          target_branch: development
-          github_token: ${{ github.token }}
       - name: Merge master -> cd4pe_development
         uses: devmasx/merge-branch@v1.3.0
         with:
@@ -38,4 +31,11 @@ jobs:
           type: now
           head_to_merge: master
           target_branch: cd4pe_production
+          github_token: ${{ github.token }}
+      - name: Merge master -> development
+        uses: devmasx/merge-branch@v1.3.0
+        with:
+          type: now
+          head_to_merge: master
+          target_branch: development
           github_token: ${{ github.token }}

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -97,7 +97,6 @@ profile::platform::baseline::enable_monitoring: false
 profile::platform::baseline::linux::packages::pkgs:
   - wget
   - unzip
-  - cron
 
 ##
 # Puppet Enterprise

--- a/data/os/Ubuntu.yaml
+++ b/data/os/Ubuntu.yaml
@@ -1,0 +1,6 @@
+---
+# Ubuntu (particularly 2022.04) requires cron to be installed for cron-provider
+profile::platform::baseline::linux::packages::pkgs:
+  - wget
+  - unzip
+  - cron

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -12,11 +12,12 @@ hierarchy:
   - name: 'Environment data'
     lookup_key: eyaml_lookup_key
     paths:
-      - 'nodes/%{::fqdn}.yaml'
+      - 'nodes/%{facts.networking.fqdn}.yaml'
       - 'location/%{::location}/%{::role}.yaml'
       - 'role/%{::tier}/%{::role}.yaml'
       - 'role/%{::role}.yaml'
       - 'location/%{::location}.yaml'
+      - 'os/%{facts.os.name}.yaml'
       - 'common.yaml'
   - name: 'Local data'
     lookup_key: eyaml_lookup_key


### PR DESCRIPTION
Ubuntu 22.04 needs to have cron installed.  RHEL and CentOS don't have a cron package, so putting it in common.yaml breaks.  This changes adds an os/Ubuntu.yaml piece to the hiera hierarchy, puts the standard packages in it, and removes cron from common.yaml.  Also, minor update to use facts.networking.fqdn instead of the legacy fqdn fact in the hiera.conf.