### PR TITLE
Winpkg

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -136,6 +136,11 @@ profile::platform::baseline::enable_monitoring: false
 profile::platform::baseline::linux::packages::pkgs:
   - wget
   - unzip
+profile::platform::baseline::windows::packages::pkgs:
+  - notepadplusplus
+  - 7zip
+  - git
+  - uniextract
 
 ##
 # Puppet Enterprise

--- a/site-modules/profile/manifests/platform/baseline/linux/ssh.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/ssh.pp
@@ -1,11 +1,10 @@
-#
 class profile::platform::baseline::linux::ssh () {
   # Determine the type of node which will drive which settings are applied
   case $facts['certname'] {
     /^.*(cd4pe|comply).*/: { $node_type = 'puppet_application_manager' }
     /^puppet.*/: { $node_type = 'puppet_server' }
     /^.*gitlab.*/: { $node_type = 'gitlab' }
-    /^.*(rhel|ubu|nix).*$/, default: { $node_type = 'generic' }
+    /^.*(rhel|ubu|nix|alma|al2023|ol8|rocky|deb|suse).*$/, default: { $node_type = 'generic' }
   }
 
   case $node_type {

--- a/site-modules/profile/manifests/platform/baseline/windows/motd.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows/motd.pp
@@ -1,37 +1,38 @@
 # class: profile::platform::baseline::windows::motd
 #
 class profile::platform::baseline::windows::motd {
-  $motd = @("MOTD"/L)
-    ===========================================================
+  if !defined(Class['sce_windows']) {
+    $motd = @("MOTD"/L)
+      ===========================================================
 
-          Welcome to ${facts['networking']['hostname']}
+           Welcome to ${facts['networking']['hostname']}
 
-    Access  to  and  use of this server is  restricted to those
-    activities expressly permitted by the system administration
-    staff. If you are not sure if it is allowed, then DO NOT DO IT.
+      Access  to  and  use of this server is  restricted to those
+      activities expressly permitted by the system administration
+      staff. If you are not sure if it is allowed, then DO NOT DO IT.
 
-    ===========================================================
+      ===========================================================
 
-    The operating system is: ${facts['os']['name']}
-            The domain is: ${facts['networking']['domain']}
+      The operating system is: ${facts['os']['name']}
+              The domain is: ${facts['networking']['domain']}
 
-    | MOTD
+      | MOTD
 
 
-  # Check if we have a hiera override for the MOTD, otherwise use the default
-  $message = lookup('motd', String, 'first', $motd)
+    # Check if we have a hiera override for the MOTD, otherwise use the default
+    $message = lookup('motd', String, 'first', $motd)
 
-  registry_value { '32:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\policies\system\legalnoticecaption':
-    ensure => present,
-    type   => string,
-    data   => 'Message of the day',
+    registry_value { '32:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\policies\system\legalnoticecaption':
+      ensure => present,
+      type   => string,
+      data   => 'Message of the day',
+    }
+
+    registry_value { '32:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\policies\system\legalnoticetext':
+      ensure => present,
+      type   => string,
+      data   => $message,
+    }
   }
-
-  registry_value { '32:HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\policies\system\legalnoticetext':
-    ensure => present,
-    type   => string,
-    data   => $message,
-  }
-
 }
 

--- a/site-modules/profile/manifests/platform/baseline/windows/packages.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows/packages.pp
@@ -1,11 +1,12 @@
-class profile::platform::baseline::windows::packages {
+class profile::platform::baseline::windows::packages (
+  Array[String] $pkgs
+){
 
   Package {
     provider => chocolatey,
   }
 
-  $predefined_packages = [ 'notepadplusplus', '7zip', 'git', 'uniextract' ]
-  package { $predefined_packages:
+  package { $pkgs:
     ensure => present
   }
 


### PR DESCRIPTION
Convert Windows package installation manifest to use hiera instead of hardcoded list.
Fix Windows MOTD manifest to not conflict with SCE control.
Set all new OSes to generic baseline.