### PR TITLE
Fix OS name used for Alma Linux nodes.

### DIFF
--- a/site-modules/profile/functions/firewall_type.pp
+++ b/site-modules/profile/functions/firewall_type.pp
@@ -1,6 +1,6 @@
 function profile::firewall_type(String $os, String $version) >> String {
   $os_firewalls = {
-    'alma' => {
+    'almalinux' => {
       '8' => 'firewalld',
       '9' => 'firewalld',
     },


### PR DESCRIPTION
This will fix the issue for applying the baseline firewall to AlmaLinux 8 and 9 nodes.