### PR TITLE
Update hiera.yaml to include clientcert for node level configuration.

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -14,6 +14,7 @@ hierarchy:
       var: trusted.external.servicenow.hiera_data
   - name: 'Environment data'
     paths:
+      - 'nodes/%{facts.clientcert}.yaml'
       - 'nodes/%{facts.networking.fqdn}.yaml'
       - 'location/%{::location}/%{::role}.yaml'
       - 'role/%{::tier}/%{::role}.yaml'


### PR DESCRIPTION
Allows the use of fqdn or clientcert for hiera. 
This fixes the "*.ec2.internal.yaml" vs "*.se.automationdemos.com.yaml" confusion by simply allowing either file to work.