### PR TITLE
SEP-568 - Puppetfile cleanup and module version updates

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,108 +1,113 @@
 # Modules from the Puppet Forge
 # Versions should be updated to be the latest at the time you start
+
+## Puppet Core Modules
 mod 'puppetlabs-augeas_core', '1.5.0'
 mod 'puppetlabs-host_core', '1.3.0'
 mod 'puppetlabs-selinux_core', '1.4.0'
 mod 'puppetlabs-sshkeys_core', '2.5.0'
 mod 'puppetlabs-yumrepo_core', '2.1.0'
-mod 'puppetlabs-acl', '5.0.1'
-mod 'puppetlabs-apache', '12.1.0'
-mod 'puppetlabs-apt', '9.4.0'
-mod 'puppetlabs-aws', '2.1.0'
-mod 'puppetlabs-cd4pe', '3.3.0'
-mod 'puppetlabs-cd4pe_jobs', '1.7.0'
-mod 'puppetlabs-chocolatey', '8.0.0'
-mod 'puppetlabs-comply', '3.3.1'
-mod 'puppet-chrony', '3.0.0'
-mod 'puppetlabs-concat', '9.0.2'
-mod 'puppetlabs-dism', '1.3.1'
-mod 'puppetlabs-docker', '10.0.1'
-mod 'puppetlabs-exec', '3.0.0'
-mod 'puppetlabs-facter_task', '2.0.1'
-mod 'puppetlabs-firewall', '8.0.3'
-mod 'kogitoapp-ufw', '1.0.3'
-mod 'puppetlabs-git', '0.5.0'
-mod 'puppetlabs-haproxy', '8.0.0'
+mod 'puppet-augeasproviders_core', '4.1.0'
+
+# Base Library Modules
+mod 'puppetlabs-concat', '9.1.0'
+mod 'puppetlabs-inifile', '6.2.0'
 mod 'puppetlabs-hocon', '2.0.0'
-mod 'puppetlabs-iis', '10.0.0'
-mod 'puppetlabs-inifile', '6.1.1'
-mod 'puppetlabs-java', '11.0.0'
-mod 'saz-limits', '4.0.1'
-mod 'puppetlabs-motd', '7.1.0'
-#mod 'puppetlabs-mount_iso', '4.0.3' # Needs updated to support powershell 4.0.0
-mod 'puppetlabs-node_manager', '1.0.1'
-mod 'puppetlabs-ntp', '10.1.0'
-mod 'puppetlabs-powershell', '6.0.0'
-mod 'puppetlabs-puppet_authorization', '1.0.0'
-mod 'puppetlabs-puppetserver_gem', '1.1.1'
-mod 'puppetlabs-pwshlib', '1.2.0'
-mod 'puppetlabs-reboot', '5.0.0'
-mod 'puppetlabs-registry', '5.0.1'
-mod 'puppetlabs-resource', '1.1.0'
-mod 'puppetlabs-ruby_task_helper', '0.6.1'
-mod 'puppetlabs-terraform', '0.7.1'
-mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
-mod 'puppetlabs-service', '3.0.0'
-mod 'puppetlabs-servicenow_reporting_integration', '1.0.0'
-mod 'puppetlabs-splunk_hec', '2.0.0' # Missing requirement of puppetlabs-puppet_metrics_collector
-mod 'puppetlabs-stdlib', '9.6.0'
-mod 'puppetlabs-tomcat', '7.2.0'
+mod 'puppetlabs-exec', '3.1.0'
+mod 'puppetlabs-ruby_task_helper', '1.0.0'
+mod 'puppetlabs-ruby_plugin_helper', '0.3.0'
+mod 'puppetlabs-stdlib', '9.7.0'
 mod 'puppetlabs-transition', '2.0.0'
-mod 'puppetlabs-vcsrepo', '6.1.0'
+mod 'ipcrm-echo', '0.1.8'
+mod 'puppet-hiera', '6.0.0'
+#mod 'crayfishx-purge', '1.2.1' # Very likely unused. `purge` is now a default Puppet meta-parameter. Uncomment if needed, remove in a future revision.
+
+## Package & Archive Management
+mod 'puppetlabs-apt', '10.0.0'
+mod 'puppetlabs-puppet_agent', '4.21.0'
+mod 'puppet-yum', '7.2.0' # Required for CD4PE workshop
+#mod 'computology-packagecloud', '0.3.2' # likely unused, uncomment and run code deploy if needed
+mod 'puppet-archive', '7.1.0'
+mod 'puppet-zypprepo', '5.0.0'
+
+## Puppet Application Specific Modules
+mod 'puppetlabs-cd4pe_jobs', '1.7.1'
+mod 'puppetlabs-comply', '3.3.1'
+mod 'puppetlabs-puppet_authorization', '1.0.0'
+mod 'puppetlabs-puppetserver_gem', '1.1.1'     # gem package provider for puppetserver specific gems
+#mod 'puppetlabs-cd4pe', '3.3.0'               # No longer required since PE 2019. Remove in a future revision.
+
+## Linux OS & Featrue Management Modules
+mod 'puppetlabs-firewall', '8.1.3'
+mod 'puppetlabs-ntp', '11.0.0'
+mod 'puppet-chrony', '3.0.0'
+mod 'bodgit-rngd', '3.0.1'  # potentially unused, review in a future revision
+mod 'kogitoapp-ufw', '1.0.3'
+mod 'saz-limits', '5.0.0'
+mod 'ghoneycutt-ssh', '5.1.1'
+mod 'puppet-epel', '5.0.0'
+mod 'puppet-firewalld', '5.0.0'
+mod 'puppet-logrotate', '7.1.0'
+mod 'puppet-selinux', '4.1.0' # 5.0.0+ is available, however sce_linux requires '< 5.0.0', *might* work regardless, should be tested and updated, if so.
+mod 'puppet-systemd', '8.1.0' # 8.1.0+ is available, however sce_linux requires '< 7.0.0', *might* work regardless, should be tested and updated, if so.
+# mod 'nexcess-auditd', '4.2.0' # Part of `profile::compliance::hippa`. Likely unused. Uncomment if needed and run code deploy.
+
+## Windows OS & Feature Management Modules
+mod 'puppetlabs-acl', '5.0.2'
+mod 'puppetlabs-dism', '1.3.1'
+mod 'puppetlabs-iis', '10.0.1'
+mod 'puppetlabs-powershell', '6.0.1'
+mod 'puppetlabs-registry', '5.0.2'
 mod 'dsc-networkingdsc', '9.0.0-0-8'
 mod 'dsc-auditpolicydsc', '1.4.0-0-9'
 mod 'dsc-securitypolicydsc', '2.10.0-0-9'
-mod 'puppetlabs-puppet_agent', :latest
-
-# Forge Community Modules
-mod 'puppet-yum', '7.1.0'  # Required for the CD4PE workshop
-mod 'WhatsARanjit-diskspace', '0.2.0'
 mod 'ayohrling-local_security_policy', '1.1.1'
-mod 'bodgit-rngd', '3.0.1'
-mod 'computology-packagecloud', '0.3.2'
-mod 'crayfishx-purge', '1.2.1'
-mod 'ghoneycutt-ssh', '5.0.0'
-mod 'puppet-augeasproviders_core', '4.1.0'
-#mod 'hunner-wordpress', '1.0.0'
-#mod 'ipcrm-echo', '0.1.8'
-#mod 'kogitoapp-gitea', '1.0.4' # Do we need this, it is out of date and requires very old inifile and stdlib; part of
-                              # profile::puppet::seteam_master
-#mod 'lwf-remote_file', '1.1.3'
-mod 'nexcess-auditd', '4.2.0' # Part of profile::compliance::hippa
-mod 'puppet-archive', '7.1.0'
-mod 'puppet-epel', '5.0.0'
-
-mod 'puppet-firewalld',     # Using a custom fork of the firewalld for proper pacakge management / dependancy management
-    git: 'https://github.com/puppetlabs-seteam/puppet-firewalld.git',
-    branch: 'master'
-
-mod 'puppet-prometheus', '15.0.0'
-mod 'puppet-grafana', '14.1.0'
-mod 'puppet-gitlab', '9.0.0'
-mod 'puppet-hiera', '6.0.0'
-mod 'puppet-logrotate', '7.1.0'
-mod 'puppet-nginx', '6.0.0'
-mod 'puppet-php', '10.2.0' # Requires zypprepo
-mod 'puppet-python', '7.3.0'
-mod 'puppet-selinux', '4.1.0'
-mod 'puppet-splunk', '10.0.0'
-mod 'puppet-systemd', '7.1.0'
-mod 'webalex-windows_firewall', '1.5.1'
+mod 'webalex-windows_firewall', '1.7.0'
 mod 'puppet-windowsfeature', '5.0.0'
-mod 'reidmv-unzip', '0.1.2'
-mod 'trlinkin-domain_membership', '1.1.2'
-mod 'tse-time', '1.0.1'
-mod 'tse-winntp', '1.0.1'
-mod 'puppet-staging', '3.2.0'
-mod 'artsir-ansible_config', '1.1.3'
+#mod 'reidmv-unzip', '0.1.2' # likely unused. `puppet-archive` should support unzip for windows. Uncomment if needed.
+#mod 'trlinkin-domain_membership', '1.1.2' # likley unused. DSC methods should be used currently. Uncomment if needed.
 
-# This is missing dependency on mayflower-php, needs updated to use puppet-php at least
-# This is missing dependency on puppet-app_modeling, is it needed?
-#mod 'rgbank',
-#    git:            'https://github.com/puppetlabs-seteam/puppetlabs-rgbank.git',
-#    branch:         :control_branch,
-#    default_branch: 'master'
+## Common OS & Feature Modules
+mod 'puppetlabs-motd', '7.2.0'
+mod 'puppetlabs-pwshlib', '1.2.2'
 
-#mod 'netstat',
-#    git: 'https://github.com/ipcrm/ipcrm-netstat.git',
-#    ref: '64bcee0'
+## Utility modules
+mod 'puppetlabs-facter_task', '2.1.0'
+mod 'puppetlabs-node_manager', '1.1.0'
+mod 'puppetlabs-reboot', '5.0.0'
+mod 'puppetlabs-vcsrepo', '6.1.0'
+mod 'artsir-ansible_config', '1.1.3'   # likely unused. Should be reviewed at a future revision. 
+#mod 'puppetlabs-resource', '1.1.0'    # deprecated: likely unused. Uncomment if needed. Remove in future revision.
+#mod 'puppetlabs-service', '3.1.0'     # likely ununsed, there is a service task already packaged with PE. Uncomment if needed.
+#mod 'WhatsARanjit-diskspace', '0.2.0' # likely ununsed, there are core facts now available for this. Uncomment if needed.
+#mod 'lwf-remote_file', '1.1.3'        # likely unused, Puppet's `file` resource type now allows HTTP sources. Uncomment if needed.
+#mod 'puppet-staging', '3.2.0'         # Deprecated: Likely ununsed. Uncomment and run code deploy if needed.
+#mod 'tse-time', '1.0.1'               # Likely ununsed. Uncomment and run code deploy if needed.
+#mod 'tse-winntp', '1.0.1'             # Likely ununsed. Uncomment and run code deploy if needed.
+
+## Application & Middleware Modules
+mod 'puppetlabs-apache', '12.2.0'
+mod 'puppetlabs-chocolatey', '8.0.1'
+mod 'puppetlabs-docker', '10.1.0'
+mod 'puppetlabs-haproxy', '8.1.0'
+mod 'puppetlabs-java', '11.1.0'
+mod 'puppetlabs-terraform', '0.7.1'
+mod 'puppetlabs-tomcat', '7.4.0'
+mod 'puppet-grafana', '14.1.0'
+mod 'puppet-gitlab', '10.1.0'
+mod 'puppet-nginx', '6.0.1'
+mod 'puppet-php', '10.2.0'
+mod 'puppet-prometheus', '16.0.0'
+mod 'puppet-python', '7.4.0'
+
+## ServiceNOW Integrations 
+## NOTE: These are disabled by default, uncomment and run code deploy if needed for a specific demo
+# mod 'puppetlabs-servicenow_reporting_integration', '1.0.0'
+# mod 'puppetlabs-servicenow_change_requests', '0.4.1'
+# mod 'puppetlabs-servicenow_cmdb_integration', '0.2.0'
+
+## Splunk Integrations
+## NOTE: These are disabled by default, uncomment and run code deploy if needed for a specific demo
+# mod 'puppet-splunk', '10.0.0'
+# mod 'puppetlabs-splunk_hec', '2.0.1'
+

--- a/Puppetfile
+++ b/Puppetfile
@@ -29,7 +29,7 @@ mod 'puppetlabs-inifile', '6.1.1'
 mod 'puppetlabs-java', '11.0.0'
 mod 'saz-limits', '4.0.1'
 mod 'puppetlabs-motd', '7.1.0'
-mod 'puppetlabs-mount_iso', '4.0.3' # Needs updated to support powershell 4.0.0
+#mod 'puppetlabs-mount_iso', '4.0.3' # Needs updated to support powershell 4.0.0
 mod 'puppetlabs-node_manager', '1.0.1'
 mod 'puppetlabs-ntp', '10.1.0'
 mod 'puppetlabs-powershell', '6.0.0'
@@ -63,11 +63,11 @@ mod 'computology-packagecloud', '0.3.2'
 mod 'crayfishx-purge', '1.2.1'
 mod 'ghoneycutt-ssh', '5.0.0'
 mod 'puppet-augeasproviders_core', '4.1.0'
-mod 'hunner-wordpress', '1.0.0'
-mod 'ipcrm-echo', '0.1.8'
-mod 'kogitoapp-gitea', '1.0.4' # Do we need this, it is out of date and requires very old inifile and stdlib; part of
+#mod 'hunner-wordpress', '1.0.0'
+#mod 'ipcrm-echo', '0.1.8'
+#mod 'kogitoapp-gitea', '1.0.4' # Do we need this, it is out of date and requires very old inifile and stdlib; part of
                               # profile::puppet::seteam_master
-mod 'lwf-remote_file', '1.1.3'
+#mod 'lwf-remote_file', '1.1.3'
 mod 'nexcess-auditd', '4.2.0' # Part of profile::compliance::hippa
 mod 'puppet-archive', '7.1.0'
 mod 'puppet-epel', '5.0.0'
@@ -98,11 +98,11 @@ mod 'artsir-ansible_config', '1.1.3'
 
 # This is missing dependency on mayflower-php, needs updated to use puppet-php at least
 # This is missing dependency on puppet-app_modeling, is it needed?
-mod 'rgbank',
-    git:            'https://github.com/puppetlabs-seteam/puppetlabs-rgbank.git',
-    branch:         :control_branch,
-    default_branch: 'master'
+#mod 'rgbank',
+#    git:            'https://github.com/puppetlabs-seteam/puppetlabs-rgbank.git',
+#    branch:         :control_branch,
+#    default_branch: 'master'
 
-mod 'netstat',
-    git: 'https://github.com/ipcrm/ipcrm-netstat.git',
-    ref: '64bcee0'
+#mod 'netstat',
+#    git: 'https://github.com/ipcrm/ipcrm-netstat.git',
+#    ref: '64bcee0'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -8,10 +8,10 @@ defaults:
     pkcs7_public_key: /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem
 
 hierarchy:
-  - name: "ServiceNow Hiera data"
-    data_hash: servicenow_cmdb_integration::getvar
-    options:
-      var: trusted.external.servicenow.hiera_data
+#  - name: "ServiceNow Hiera data"
+#    data_hash: servicenow_cmdb_integration::getvar
+#    options:
+#      var: trusted.external.servicenow.hiera_data
   - name: 'Environment data'
     paths:
       - 'nodes/%{facts.clientcert}.yaml'

--- a/site-modules/profile/manifests/platform/baseline/firewall/firewalld.pp
+++ b/site-modules/profile/manifests/platform/baseline/firewall/firewalld.pp
@@ -18,7 +18,7 @@ class profile::platform::baseline::firewall::firewalld (
   class { 'firewalld':
     service_ensure            => running,
     service_enable            => true,
-    manage_package            => false,
+    package_ensure            => false,
     purge_direct_rules        => true,
     purge_direct_chains       => true,
     purge_direct_passthroughs => true,

--- a/site-modules/profile/manifests/platform/baseline/linux/packages.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/packages.pp
@@ -9,11 +9,13 @@ class profile::platform::baseline::linux::packages (
 
   ensure_packages($pkgs, {ensure => installed})
 
-  unless getvar('trusted.external.servicenow.u_enforced_packages').empty {
-    $packages = parsejson($trusted['external']['servicenow']['u_enforced_packages'])
-    $packages.each |$package,$ensure|{
-      package { $package:
-        ensure => $ensure
+  if defined(Class['servicenow_cmdb_integration']) {
+    unless getvar('trusted.external.servicenow.u_enforced_packages').empty {
+      $packages = parsejson($trusted['external']['servicenow']['u_enforced_packages'])
+      $packages.each |$package,$ensure|{
+        package { $package:
+          ensure => $ensure
+        }
       }
     }
   }

--- a/site-modules/profile/manifests/platform/baseline/windows/packages.pp
+++ b/site-modules/profile/manifests/platform/baseline/windows/packages.pp
@@ -10,11 +10,13 @@ class profile::platform::baseline::windows::packages (
     ensure => present
   }
 
-  unless getvar('trusted.external.servicenow.u_enforced_packages').empty {
-    $packages = parsejson($trusted['external']['servicenow']['u_enforced_packages'])
-    $packages.each |$package,$ensure|{
-      package { $package:
-        ensure => $ensure
+  if defined(Class['servicenow_cmdb_integration']) {
+    unless getvar('trusted.external.servicenow.u_enforced_packages').empty {
+      $packages = parsejson($trusted['external']['servicenow']['u_enforced_packages'])
+      $packages.each |$package,$ensure|{
+        package { $package:
+          ensure => $ensure
+        }
       }
     }
   }


### PR DESCRIPTION
`Puppetfile` Changes: 
- Updated all modules to current versions.
- Remove several modules known to be unused.
- Reorder headings for better overall `Puppetfile` organization.
- Comment out and tag "likely unused" modules for future removal.
- Add, but leave commented out modules for ServiceNow and Splunk integrations (can, and should be enabled on a per demo basis).
- Tag some suspect modules for review at a future date (but leave them enabled for now).
- Checked the new `Puppetfile` against the Puppet forge validator. 
- All modules are up to date aside from `puppet-selinux`, which is locked at '4.1.0' (instead of '5.0.0') to support `sce_linux`.

`profile::platform::baseline::firewall::firewalld` Changes:
- Previously a forked version of the `firewalld` module was used to support what is now available as the `ensure_package` parameter. Update to use this parameter and version of the module.