### PR TITLE
SEP-568 - Part 2 - Additional fixes required for cleanup.

### DIFF
--- a/site-modules/profile/manifests/platform/baseline/firewall/firewalld.pp
+++ b/site-modules/profile/manifests/platform/baseline/firewall/firewalld.pp
@@ -13,12 +13,11 @@ class profile::platform::baseline::firewall::firewalld (
   Boolean $allow_ingress_icmpv4 = $profile::platform::baseline::firewall::allow_ingress_icmpv4,
   Array[Hash] $allow_ingress    = $profile::platform::baseline::firewall::allow_ingress_linux_default + $profile::platform::baseline::firewall::allow_ingress, #lint:ignore:140chars
 ) {
-  ensure_resource('package','firewalld', { ensure => present })
 
   class { 'firewalld':
     service_ensure            => running,
     service_enable            => true,
-    package_ensure            => false,
+    package_ensure            => 'present',
     purge_direct_rules        => true,
     purge_direct_chains       => true,
     purge_direct_passthroughs => true,

--- a/site-modules/profile/manifests/platform/baseline/firewall/firewalld.pp
+++ b/site-modules/profile/manifests/platform/baseline/firewall/firewalld.pp
@@ -22,7 +22,6 @@ class profile::platform::baseline::firewall::firewalld (
     purge_direct_chains       => true,
     purge_direct_passthroughs => true,
     purge_unknown_ipsets      => true,
-    require                   => Package['firewalld'],
   }
 
   $icmp_block_inversion = $allow_ingress_icmpv4 ? { true => false, false => true }

--- a/site-modules/profile/manifests/platform/baseline/linux/vim.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/vim.pp
@@ -2,12 +2,6 @@
 #
 class profile::platform::baseline::linux::vim {
 
-  require ::git
-
-  $users = {
-    'root'  => '/root',
-  }
-
   case $facts['os']['family'] {
     'Debian': {
       $package = 'vim-nox'


### PR DESCRIPTION
- Fixed firewalld parameter to use enum for `package_ensure => 'present'`
- Fixed vim.pp in baseline profile. Removed superfluous call to include `git` class.