### PR TITLE
RHEL 9+, Ubuntu 24.04+ dont use mod_php

### DIFF
--- a/site-modules/profile/manifests/app/webserver/apache/php.pp
+++ b/site-modules/profile/manifests/app/webserver/apache/php.pp
@@ -1,3 +1,9 @@
 class profile::app::webserver::apache::php {
-  include ::apache::mod::php
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '9' {
+    # RHEL9 (technically 8...) and above don't use mod_php
+  } elsif $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['major'] >= '24.04' {
+    # Ubuntu 24.04 and above don't use mod_php
+  } else {
+    include ::apache::mod::php
+  }
 }


### PR DESCRIPTION
This enabled the sample_website role to run on RHEL9 and Ubuntu 24.04.  There's a similar problem with AL2023, but I haven't quite cracked it...