### PR TITLE
No longer remove and disable the SSH Service. 

### DIFF
--- a/site-modules/profile/manifests/platform/baseline/linux/sshd/sshd_remove.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux/sshd/sshd_remove.pp
@@ -9,8 +9,8 @@ class profile::platform::baseline::linux::sshd::sshd_remove {
       -> package { 'openssh-server': ensure => absent, }
     }
     default: {
-      service { 'sshd': ensure => stopped, enable => false, }
-      -> package { 'openssh-server': ensure => absent, }
+      # service { 'sshd': ensure => stopped, enable => false, }
+      # -> package { 'openssh-server': ensure => absent, }
     }
   }
 }


### PR DESCRIPTION
Host based firewall rules will still prevent access from the world to SSHD service.