### PR TITLE
cleanup and add firewall_type definitions

### DIFF
--- a/site-modules/profile/functions/firewall_type.pp
+++ b/site-modules/profile/functions/firewall_type.pp
@@ -1,26 +1,24 @@
 function profile::firewall_type(String $os, String $version) >> String {
   $os_firewalls = {
     'almalinux' => {
-      '8' => 'firewalld',
-      '9' => 'firewalld',
-    },
-    'centos' => {
-      '7' => 'iptables',
-      '8' => 'firewalld',
+      '8'  => 'firewalld',
+      '9'  => 'firewalld',
+      '10' => 'firewalld',
     },
     'oraclelinux' => {
-      '7' => 'iptables',
-      '8' => 'firewalld',
-      '9' => 'firewalld',
+      '8'  => 'firewalld',
+      '9'  => 'firewalld',
+      '10' => 'firewalld',
     },
     'redhat' => {
-      '7' => 'iptables',
-      '8' => 'firewalld',
-      '9' => 'firewalld',
+      '8'  => 'firewalld',
+      '9'  => 'firewalld',
+      '10' => 'firewalld',
     },
     'rocky' => {
-      '8' => 'firewalld',
-      '9' => 'firewalld',
+      '8'  => 'firewalld',
+      '9'  => 'firewalld',
+      '10' => 'firewalld',
     },
     'ubuntu' => {
       '20.04' => 'ufw',
@@ -33,6 +31,7 @@ function profile::firewall_type(String $os, String $version) >> String {
       '2016' => 'windows',
       '2019' => 'windows',
       '2022' => 'windows',
+      '2025' => 'windows',
     },
   }
 


### PR DESCRIPTION
The diff looks kind of weird, but I removed CentOS and EL7, added EL10 and Windows 2025 for when we get to adding newer Windows versions.