### PR TITLE
Disable SSH lockdown, but leave in place as an example.

### DIFF
--- a/data/sce/Ubuntu/24.04.yaml
+++ b/data/sce/Ubuntu/24.04.yaml
@@ -1,0 +1,21 @@
+# SCE Linux for Ubuntu 24.04
+sce_linux::config:
+  profile: 'server'
+  level: '1'
+  firewall_type: 'unmanaged'
+  control_configs:
+    ensure_password_creation_requirements_are_configured:
+      password_auth_file: 'password-auth-ac'
+      system_auth_file: 'system-auth-ac'
+      password_auth_symlink: 'password-auth'
+      system_auth_symlink: 'system-auth'   
+  ignore:
+    - 'ensure_rsync_is_not_installed_or_the_rsyncd_service_is_masked'
+    - 'ensure_message_of_the_day_is_configured_properly'
+    - 'ensure_permissions_on_etcmotd_are_configured'
+    - 'ensure_permissions_on_etcsshsshd_config_are_configured'
+    - 'ensure_iptables_packages_are_installed'
+    - 'ensure_firewalld_is_installed'
+    - 'ensure_firewalld_service_is_enabled_and_running'
+    - 'ensure_time_synchronization_is_in_use'
+    - 'ensure_rpcbind_services_are_not_in_use'

--- a/data/sce/sce_defaults.yaml
+++ b/data/sce/sce_defaults.yaml
@@ -33,4 +33,3 @@ sce_linux::config:
     - 'ensure_firewalld_is_installed'
     - 'ensure_firewalld_service_is_enabled_and_running'
     - 'ensure_time_synchronization_is_in_use'
-    - 'ensure__rpc_is_not_installed'

--- a/data/sce/sce_defaults.yaml
+++ b/data/sce/sce_defaults.yaml
@@ -33,3 +33,4 @@ sce_linux::config:
     - 'ensure_firewalld_is_installed'
     - 'ensure_firewalld_service_is_enabled_and_running'
     - 'ensure_time_synchronization_is_in_use'
+    - 'ensure__rpc_is_not_installed'

--- a/site-modules/profile/manifests/platform/baseline/linux.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux.pp
@@ -7,7 +7,8 @@ class profile::platform::baseline::linux {
   include profile::platform::baseline::linux::users
 
   if $facts['deployment_status'] == 'Complete' {
-    #include profile::platform::baseline::linux::ssh
+# SSH baseline intentionally disabled; re-enable when SSH lockdown is ready to deploy.
+# include profile::platform::baseline::linux::ssh
     include profile::platform::baseline::linux::sudo
   }
 

--- a/site-modules/profile/manifests/platform/baseline/linux.pp
+++ b/site-modules/profile/manifests/platform/baseline/linux.pp
@@ -7,7 +7,7 @@ class profile::platform::baseline::linux {
   include profile::platform::baseline::linux::users
 
   if $facts['deployment_status'] == 'Complete' {
-    include profile::platform::baseline::linux::ssh
+    #include profile::platform::baseline::linux::ssh
     include profile::platform::baseline::linux::sudo
   }
 


### PR DESCRIPTION
Comment out the inclusion of the SSH profile based on deployment status.